### PR TITLE
Exception handling in FileStore

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -10,6 +10,8 @@ module FakeS3
   class FileStore
     SHUCK_METADATA_DIR = ".fakes3_metadataFFF"
 
+    attr_accessor :logger
+
     def initialize(root)
       @root = root
       @buckets = []
@@ -83,8 +85,7 @@ module FakeS3
         real_obj.io = RateLimitableFile.open(File.join(obj_root,"content"),'rb')
         return real_obj
       rescue
-        puts $!
-        $!.backtrace.each { |line| puts line }
+        handle_exception $!
         return nil
       end
     end
@@ -170,8 +171,7 @@ module FakeS3
         bucket.add(obj)
         return obj
       rescue
-        puts $!
-        $!.backtrace.each { |line| puts line }
+        handle_exception $!
         return nil
       end
     end
@@ -183,10 +183,24 @@ module FakeS3
         object = bucket.find(object_name)
         bucket.remove(object)
       rescue
-        puts $!
-        $!.backtrace.each { |line| puts line }
+        handle_exception $!
         return nil
       end
+    end
+
+    private
+
+    def log message
+      if (logger)
+        logger.warn message
+      else
+        warn message
+      end
+    end
+
+    def handle_exception e
+      log e.inspect
+      e.backtrace.each { |line| log line }
     end
   end
 end

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -42,6 +42,7 @@ module FakeS3
     def initialize(server,store,hostname)
       super(server)
       @store = store
+      @store.logger = @logger
       @hostname = hostname
       @root_hostnames = [hostname,'localhost','s3.amazonaws.com','s3.localhost']
     end


### PR DESCRIPTION
Hi Curtis,

Since the Webrick has it's own logger I thought it would be good to use it
to log exceptions in FileStore. At the moment the stacktrace is sent directly to
the standard output. 

I work on a project that's using FakeS3 in its test and dev environments. We have
a lot of noise caused by the FileStore exception stacktraces in our rspec / cucmber tests.
Redirecting the stacktraces to server's log seems like a cleaner soultion.

I've made a change so that if the logger is specified, the backtrace will be send 
to the logger as a warning. If the logger is not set, the backtrace will be send 
to the standard error.

Cheers,
Tomasz
