### PR TITLE
Support for storing and retrieving custom metadata for S3 objects

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -84,6 +84,7 @@ module FakeS3
         real_obj.size = metadata.fetch(:size) { 0 }
         real_obj.creation_date = File.ctime(obj_root).iso8601()
         real_obj.modified_date = metadata.fetch(:modified_date) { File.mtime(File.join(obj_root,"content")).iso8601() }
+        real_obj.custom_metadata = metadata.fetch(:custom_metadata) { {} }
         return real_obj
       rescue
         puts $!
@@ -164,6 +165,14 @@ module FakeS3
         metadata_struct[:content_type] = request.header["content-type"].first
         metadata_struct[:size] = File.size(content)
         metadata_struct[:modified_date] = File.mtime(content).iso8601()
+        metadata_struct[:custom_metadata] = {}
+
+        request.header.each do |key, value|
+          match = /^x-amz-meta-(.*)$/.match(key)
+          if match
+            metadata_struct[:custom_metadata][match[1]] = value.join(', ')
+          end
+        end
 
         File.open(metadata,'w') do |f|
           f << YAML::dump(metadata_struct)

--- a/lib/fakes3/s3_object.rb
+++ b/lib/fakes3/s3_object.rb
@@ -1,7 +1,7 @@
 module FakeS3
   class S3Object
     include Comparable
-    attr_accessor :name,:size,:creation_date,:modified_date,:md5,:io,:content_type
+    attr_accessor :name,:size,:creation_date,:modified_date,:md5,:io,:content_type,:custom_metadata
 
     def hash
       @name.hash

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -94,6 +94,10 @@ module FakeS3
         response['Accept-Ranges'] = "bytes"
         response['Last-Ranges'] = "bytes"
 
+        real_obj.custom_metadata.each do |header, value|
+          response.header['x-amz-meta-' + header] = value
+        end
+
         content_length = stat.size
 
         # Added Range Query support


### PR DESCRIPTION
This commit adds support and a test for storing and retrieving
custom metadata for S3 objects, as documented at:

```
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
```
