### PR TITLE
Support listing buckets by delimiter, with tests

### DIFF
--- a/lib/fakes3/bucket.rb
+++ b/lib/fakes3/bucket.rb
@@ -57,6 +57,7 @@ module FakeS3
       bq.delimiter = delimiter
       bq.matches = match_set.matches
       bq.is_truncated = match_set.is_truncated
+      bq.common_prefixes = match_set.common_prefixes
       return bq
     end
 

--- a/lib/fakes3/bucket_query.rb
+++ b/lib/fakes3/bucket_query.rb
@@ -1,7 +1,7 @@
 module FakeS3
   class BucketQuery
     attr_accessor :prefix,:matches,:marker,:max_keys,
-                  :delimiter,:bucket,:is_truncated
+                  :delimiter,:bucket,:is_truncated,:common_prefixes
 
     # Syntactic sugar
     def is_truncated?

--- a/lib/fakes3/sorted_object_list.rb
+++ b/lib/fakes3/sorted_object_list.rb
@@ -92,7 +92,7 @@ module FakeS3
             remainder = name.slice(prefix_offset, name.length)
             chunks = remainder.split(delimiter, 2)
             if chunks.length > 1
-              if (last_chunk != chunks[0]):
+              if (last_chunk != chunks[0])
                 # "All of the keys rolled up in a common prefix count as
                 # a single return when calculating the number of
                 # returns. See MaxKeys."

--- a/lib/fakes3/sorted_object_list.rb
+++ b/lib/fakes3/sorted_object_list.rb
@@ -1,10 +1,11 @@
 require 'set'
 module FakeS3
   class S3MatchSet
-    attr_accessor :matches,:is_truncated
+    attr_accessor :matches,:is_truncated,:common_prefixes
     def initialize
       @matches = []
       @is_truncated = false
+      @common_prefixes = []
     end
   end
 
@@ -73,9 +74,46 @@ module FakeS3
         end
       end
 
+      if delimiter
+        if prefix
+          base_prefix = prefix
+        else
+          base_prefix = ""
+        end
+        prefix_offset = base_prefix.length
+      end
+
       count = 0
+      last_chunk = nil
       @sorted_set.each do |s3_object|
         if marker_found && (!prefix or s3_object.name.index(prefix) == 0)
+          if delimiter
+            name = s3_object.name
+            remainder = name.slice(prefix_offset, name.length)
+            chunks = remainder.split(delimiter, 2)
+            if chunks.length > 1
+              if (last_chunk != chunks[0]):
+                # "All of the keys rolled up in a common prefix count as
+                # a single return when calculating the number of
+                # returns. See MaxKeys."
+                # (http://awsdocs.s3.amazonaws.com/S3/latest/s3-api.pdf)
+                count += 1
+                if count <= max_keys
+                  ms.common_prefixes << base_prefix + chunks[0] + delimiter
+                  last_chunk = chunks[0]
+                else
+                  is_truncated = true
+                  break
+                end
+              end
+
+              # Continue to the next key, since this one has a
+              # delimiter.
+              next
+
+            end
+          end
+
           count += 1
           if count <= max_keys
             ms.matches << s3_object
@@ -83,6 +121,7 @@ module FakeS3
             is_truncated = true
             break
           end
+
         end
 
         if marker and marker == s3_object.name

--- a/lib/fakes3/xml_adapter.rb
+++ b/lib/fakes3/xml_adapter.rb
@@ -137,6 +137,24 @@ module FakeS3
       end
     end
 
+    def self.append_common_prefixes_to_list_bucket_result(lbr,prefixes)
+      return if prefixes.nil? or prefixes.size == 0
+
+      if prefixes.index(nil)
+        require 'ruby-debug'
+        Debugger.start
+        debugger
+      end
+
+
+      lbr.CommonPrefixes { |contents|
+        prefixes.each do |common_prefix|
+          contents.Prefix(common_prefix)
+        end
+      }
+    end
+
+
     def self.bucket_query(bucket_query)
       output = ""
       bucket = bucket_query.bucket
@@ -149,6 +167,7 @@ module FakeS3
         lbr.MaxKeys(bucket_query.max_keys)
         lbr.IsTruncated(bucket_query.is_truncated?)
         append_objects_to_list_bucket_result(lbr,bucket_query.matches)
+        append_common_prefixes_to_list_bucket_result(lbr,bucket_query.common_prefixes)
       }
       output
     end

--- a/test/right_aws_commands_test.rb
+++ b/test/right_aws_commands_test.rb
@@ -44,6 +44,38 @@ class RightAWSCommandsTest < Test::Unit::TestCase
     assert_equal buf_len,output.size
   end
 
+  # Test that GET requests with a delimiter return a list of
+  def test_list_by_delimiter
+    @s3.create_bucket("s3media")
+
+    @s3.put("s3media", "delimited/item", "item")
+
+    expected_prefixes = []
+    (1..50).each do |i|
+      key_prefix = "delimited/%02d/" % i
+      @s3.put("s3media", key_prefix + "foo", "foo")
+      @s3.put("s3media", key_prefix + "fie", "fie")
+      expected_prefixes << key_prefix
+    end
+
+    key_names = []
+    common_prefixes = []
+    @s3.incrementally_list_bucket("s3media", {:prefix => "delimited", :delimiter => '/'}) do |currentResponse|
+      common_prefixes += currentResponse[:common_prefixes]
+    end
+    assert_equal ["delimited/"], common_prefixes
+
+    common_prefixes = []
+    @s3.incrementally_list_bucket("s3media", {:prefix => "delimited/", :delimiter => '/', "max-keys" => 5}) do |currentResponse|
+      key_names += currentResponse[:contents].map do |key|
+        key[:key]
+      end
+      common_prefixes += currentResponse[:common_prefixes]
+    end
+    assert_equal expected_prefixes, common_prefixes
+    assert_equal ["delimited/item"], key_names
+  end
+
   def test_multi_directory
     @s3.put("s3media","dir/right/123.txt","recursive")
     output = ""


### PR DESCRIPTION
This commit extends the GET method on buckets so that objects
can be listed using a delimiter, such that the result contains
not just a list of keys, but also (possibly) a list of common
prefixes.

For reference, see http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html