### PR TITLE
test/botocmd.py - (idempotently) create bucket instead of relying on its existence

### DIFF
--- a/test/botocmd.py
+++ b/test/botocmd.py
@@ -58,7 +58,7 @@ class FakeS3Cmd(object):
         args = list(args)
         path = args.pop()
         bucket_name, prefix = self._parse_uri(path)
-        bucket = self.conn.get_bucket(bucket_name)
+        bucket = self.conn.create_bucket(bucket_name)
         for src_file in args:
             key = Key(bucket)
             key.key = os.path.join(prefix, os.path.basename(src_file))


### PR DESCRIPTION
This pull request addresses the issue:

```
https://github.com/jubos/fake-s3/issues/24
```

wherein test/botocmd.py fails the first time that rake test is run, from a clean checkout of fake-s3.
