### PR TITLE
Fixed incompatibility with AWS Java SDK's AmazonS3Client

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -90,7 +90,7 @@ module FakeS3
         stat = File::Stat.new(real_obj.io.path)
 
         response['Last-Modified'] = stat.mtime.iso8601()
-        response['Etag'] = "\"#{real_obj.md5}\""
+        response.header['ETag'] = "\"#{real_obj.md5}\""
         response['Accept-Ranges'] = "bytes"
         response['Last-Ranges'] = "bytes"
 
@@ -141,7 +141,7 @@ module FakeS3
         end
 
         real_obj = @store.store_object(bucket_obj,s_req.object,s_req.webrick_request)
-        response['Etag'] = "\"#{real_obj.md5}\""
+        response.header['ETag'] = "\"#{real_obj.md5}\""
       when Request::CREATE_BUCKET
         @store.create_bucket(s_req.bucket)
       end


### PR DESCRIPTION
Sadly, the WEBrick Response class's [] method downcase's header names before putting them in the response header dictionary.  So 'ETag' ends up 'etag' which the AWS Java SDK doesn't recognize.  This simple fix replaces response['ETag'] = ...  call with response.header['ETag'] = ...
