### PR TITLE
Fix LS_BUCKET

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -213,10 +213,7 @@ module FakeS3
           elems = path.split("/")
         end
 
-        if elems.size == 0
-          # List buckets
-          s_req.type = Request::LIST_BUCKETS
-        elsif elems.size == 1
+        if elems.size < 2
           s_req.type = Request::LS_BUCKET
           s_req.query = query
         else


### PR DESCRIPTION
GET foo.s3.amazonaws.com/ and GET s3.amazonaws.com/foo should result in
an LS_BUCKET request, but under the previous logic it would result in a
LIST_BUCKETS request. GET s3.amazonaws.com/ still results in a
LIST_BUCKETS request due to the 'if path == "/" and s_req.is_path_style'
conditional.
