### PR TITLE
Don’t clobber contents when copying in place

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -137,7 +137,7 @@ module FakeS3
 
       case s_req.type
       when Request::COPY
-        object = @store.copy_object(s_req.src_bucket,s_req.src_object,s_req.bucket,s_req.object)
+        object = @store.copy_object(s_req.src_bucket,s_req.src_object,s_req.bucket,s_req.object,request)
         response.body = XmlAdapter.copy_object_result(object)
       when Request::STORE
         bucket_obj = @store.get_bucket(s_req.bucket)
@@ -257,7 +257,7 @@ module FakeS3
           else
             s_req.type = Request::STORE
           end
-          s_req.object = webrick_req.path
+          s_req.object = webrick_req.path[1..-1]
         end
       end
 

--- a/test/right_aws_commands_test.rb
+++ b/test/right_aws_commands_test.rb
@@ -70,6 +70,24 @@ class RightAWSCommandsTest < Test::Unit::TestCase
     assert_equal "Hello World",obj[:object]
   end
 
+  def test_copy_in_place
+    @s3.put("s3media","foo","Hello World")
+    @s3.copy("s3media","foo","s3media","foo")
+    obj = @s3.get("s3media","foo")
+    assert_equal "Hello World",obj[:object]
+  end
+
+  def test_copy_replace_metadata
+    @s3.put("s3media","foo","Hello World",{"content-type"=>"application/octet-stream"})
+    obj = @s3.get("s3media","foo")
+    assert_equal "Hello World",obj[:object]
+    assert_equal "application/octet-stream",obj[:headers]["content-type"]
+    @s3.copy("s3media","foo","s3media","foo",:replace,{"content-type"=>"text/plain"})
+    obj = @s3.get("s3media","foo")
+    assert_equal "Hello World",obj[:object]
+    assert_equal "text/plain",obj[:headers]["content-type"]
+  end
+
   def test_larger_lists
     @s3.create_bucket('right_aws_many')
     (0..50).each do |i|


### PR DESCRIPTION
Copying in place is used for updating the objects' metadata. 

Added support for x-amz-metadata-directive to replace metadata when requested.
