### PR TITLE
Amazon authentication: Fix Expect: 100-continue

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -48,6 +48,13 @@ module FakeS3
       @root_hostnames = [hostname,'localhost','s3.amazonaws.com','s3.localhost']
     end
 
+    def validate_request(request)
+      req = request.webrick_request
+      return if req.nil?
+      return if not req.header.has_key?('expect')
+      req.continue if req.header['expect'].first=='100-continue'
+    end
+
     def do_GET(request, response)
       s_req = normalize_request(request)
 
@@ -352,6 +359,8 @@ module FakeS3
       else
         raise "Unknown Request"
       end
+
+      validate_request(s_req)
 
       return s_req
     end


### PR DESCRIPTION
Amazon clients add in header expect:100-continue and is waiting for approval to send the body on the second line in socket.
Amazon server responds fast but FakeS3 has this problem. Why? Because the client is waiting for approval of the server...
How this Expect: 100 continue works?: http://www.w3.org/Protocols/rfc2616/rfc2616-sec8.html (8.2.3)

- Respond with 100 Ok if the client has "expect: 100-continue" in header