### PR TITLE
Support Content Encoding

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -79,6 +79,7 @@ module FakeS3
         real_obj.name = object_name
         real_obj.md5 = metadata[:md5]
         real_obj.content_type = metadata.fetch(:content_type) { "application/octet-stream" }
+        real_obj.content_encoding = metadata.fetch(:content_encoding)
         #real_obj.io = File.open(File.join(obj_root,"content"),'rb')
         real_obj.io = RateLimitableFile.open(File.join(obj_root,"content"),'rb')
         real_obj.size = metadata.fetch(:size) { 0 }
@@ -139,6 +140,7 @@ module FakeS3
       obj.name = dst_name
       obj.md5 = src_metadata[:md5]
       obj.content_type = src_metadata[:content_type]
+      obj.content_encoding = src_metadata[:content_encoding]
       obj.size = src_metadata[:size]
       obj.modified_date = src_metadata[:modified_date]
 
@@ -186,6 +188,7 @@ module FakeS3
         obj.name = object_name
         obj.md5 = metadata_struct[:md5]
         obj.content_type = metadata_struct[:content_type]
+        obj.content_encoding = metadata_struct[:content_encoding]
         obj.size = metadata_struct[:size]
         obj.modified_date = metadata_struct[:modified_date]
 
@@ -215,6 +218,7 @@ module FakeS3
       metadata = {}
       metadata[:md5] = Digest::MD5.file(content).hexdigest
       metadata[:content_type] = request.header["content-type"].first
+      metadata[:content_encoding] = request.header["content-encoding"].first
       metadata[:size] = File.size(content)
       metadata[:modified_date] = File.mtime(content).utc.iso8601()
       return metadata

--- a/lib/fakes3/s3_object.rb
+++ b/lib/fakes3/s3_object.rb
@@ -1,7 +1,7 @@
 module FakeS3
   class S3Object
     include Comparable
-    attr_accessor :name,:size,:creation_date,:modified_date,:md5,:io,:content_type
+    attr_accessor :name,:size,:creation_date,:modified_date,:md5,:io,:content_type,:content_encoding
 
     def hash
       @name.hash

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -90,6 +90,11 @@ module FakeS3
 
         response.status = 200
         response['Content-Type'] = real_obj.content_type
+
+        if !real_obj.content_encoding.nil?
+          response['Content-Encoding'] = real_obj.content_encoding
+        end
+
         stat = File::Stat.new(real_obj.io.path)
 
         response['Last-Modified'] = Time.iso8601(real_obj.modified_date).httpdate()


### PR DESCRIPTION
It's currently lack of content-encoding support which prohibits uploading/downloading the gzipped content to/from the fake s3 server.
