### PR TITLE
Hack to work around ruby set concurrency bug

### DIFF
--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -2,6 +2,12 @@ require 'thor'
 require 'fakes3/server'
 require 'fakes3/version'
 
+# Hack to workaround a concurrency bug in ruby.
+# Similar bug reported here:
+# https://github.com/celluloid/timers/issues/20
+require 'set'
+SortedSet.new
+
 module FakeS3
   class CLI < Thor
     default_task("server")


### PR DESCRIPTION
Lately I have been getting errors like these when running fakes3:

```
[2014-05-14 22:28:36] INFO  WEBrick 1.3.1
[2014-05-14 22:28:36] INFO  ruby 2.0.0 (2013-11-22) [x86_64-linux]
[2014-05-14 22:28:36] WARN  TCPServer Error: Address already in use - bind(2)
[2014-05-14 22:28:36] INFO  WEBrick::HTTPServer#start: pid=5090 port=4567
[2014-05-14 22:36:17] ERROR NameError: method `old_init' not defined in SortedSet
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/set.rb:619:in `remove_method'
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/set.rb:619:in `block in setup'
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/set.rb:617:in `module_eval'
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/set.rb:617:in `setup'
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/set.rb:627:in `initialize'
    /home/ubuntu/.rvm/gems/ruby-2.0.0-p353/gems/fakes3-0.1.5/lib/fakes3/sorted_object_list.rb:20:in `new'
    /home/ubuntu/.rvm/gems/ruby-2.0.0-p353/gems/fakes3-0.1.5/lib/fakes3/sorted_object_list.rb:20:in `initialize'
    /home/ubuntu/.rvm/gems/ruby-2.0.0-p353/gems/fakes3-0.1.5/lib/fakes3/bucket.rb:13:in `new'
    /home/ubuntu/.rvm/gems/ruby-2.0.0-p353/gems/fakes3-0.1.5/lib/fakes3/bucket.rb:13:in `initialize'
    /home/ubuntu/.rvm/gems/ruby-2.0.0-p353/gems/fakes3-0.1.5/lib/fakes3/file_store.rb:58:in `new'
    /home/ubuntu/.rvm/gems/ruby-2.0.0-p353/gems/fakes3-0.1.5/lib/fakes3/file_store.rb:58:in `create_bucket'
    /home/ubuntu/.rvm/gems/ruby-2.0.0-p353/gems/fakes3-0.1.5/lib/fakes3/server.rb:134:in `do_PUT'
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/webrick/httpservlet/abstract.rb:106:in `service'
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/webrick/httpserver.rb:138:in `service'
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/webrick/httpserver.rb:94:in `run'
    /home/ubuntu/.rvm/rubies/ruby-2.0.0-p353/lib/ruby/2.0.0/webrick/server.rb:295:in `block in start_thread'
localhost - - [14/May/2014:22:36:17 UTC] "PUT /.cucumber/stepdefs.json HTTP/1.1" 200 0
```

Googling for the error I found celluloid/timers#20 which suggests the bug is in ruby's `SortedSet` implementation. My pull request includes the same fix as that issue mentions.
