### PR TITLE
List buckets returning deleted buckets bug fix

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -68,6 +68,7 @@ module FakeS3
       raise NoSuchBucket if !bucket
       raise BucketNotEmpty if bucket.objects.count > 0
       FileUtils.rm_r(get_bucket_folder(bucket))
+      @buckets.delete(bucket)
       @bucket_hash.delete(bucket_name)
     end
 


### PR DESCRIPTION
Remove bucket from buckets array when deleting a bucket. This fixes a bug where a deleted bucket will still be returned in a list buckets request.
