### PR TITLE
Fix metadata file handle leak in get_object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg/*
 .bundle
 tmp
 test_root
+Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,15 +13,17 @@ GEM
       mime-types
       xml-simple
     builder (3.2.2)
-    mime-types (1.25)
-    rake (10.1.0)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
+    mime-types (2.3)
+    netrc (0.7.7)
+    rake (10.3.2)
+    rest-client (1.7.2)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     right_aws (3.1.0)
       right_http_connection (>= 1.2.5)
     right_http_connection (1.4.0)
-    thor (0.18.1)
-    xml-simple (1.1.2)
+    thor (0.19.1)
+    xml-simple (1.1.4)
 
 PLATFORMS
   ruby

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -20,6 +20,7 @@ module FakeS3
         @buckets << bucket_obj
         @bucket_hash[bucket_name] = bucket_obj
       end
+      FileUtils.mkdir_p(File.join(@root,"policies"))
     end
 
     # Pass a rate limit in bytes per second
@@ -60,6 +61,7 @@ module FakeS3
         @buckets << bucket_obj
         @bucket_hash[bucket] = bucket_obj
       end
+      File.open(File.join(@root,"policies",bucket),'w') { |file| file.write("") }
       bucket_obj
     end
 
@@ -68,6 +70,7 @@ module FakeS3
       raise NoSuchBucket if !bucket
       raise BucketNotEmpty if bucket.objects.count > 0
       FileUtils.rm_r(get_bucket_folder(bucket))
+      File.delete(File.join(@root,"policies",bucket_name))
       @bucket_hash.delete(bucket_name)
     end
 
@@ -164,7 +167,7 @@ module FakeS3
         # TODO put a tmpfile here first and mv it over at the end
 
         match=request.content_type.match(/^multipart\/form-data; boundary=(.+)/)
-      	boundary = match[1] if match
+        boundary = match[1] if match
         if boundary
           boundary = WEBrick::HTTPUtils::dequote(boundary)
           filedata = WEBrick::HTTPUtils::parse_form_data(request.body, boundary)
@@ -210,6 +213,20 @@ module FakeS3
         puts $!
         $!.backtrace.each { |line| puts line }
         return nil
+      end
+    end
+
+    def get_policy(bucket)
+      begin
+        policyname = File.join(@root,"policies",bucket)
+        return File.read(policyname)
+      end
+    end
+
+    def put_policy(bucket,policy)
+      begin
+        policyname = File.join(@root,"policies",bucket)
+        File.open(policyname,'w') { |file| file.write(policy) }
       end
     end
 


### PR DESCRIPTION
I believe this fixes the issue of being unable to delete a bucket (issue #60) shortly after (1) getting the object and (2) deleting the object. I'm not sure if there is a similar issue with `real_obj.io` being left open, but I think that might be okay because it is passed directly to `response.body` (I'm assuming that will close the stream).
