### PR TITLE
Bind "H" short option to --hostname

### DIFF
--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -10,7 +10,7 @@ module FakeS3
     method_option :root, :type => :string, :aliases => '-r', :required => true
     method_option :port, :type => :numeric, :aliases => '-p', :required => true
     method_option :address, :type => :string, :aliases => '-a', :required => false, :desc => "Bind to this address. Defaults to 0.0.0.0"
-    method_option :hostname, :type => :string, :aliases => '-h', :desc => "The root name of the host.  Defaults to s3.amazonaws.com."
+    method_option :hostname, :type => :string, :aliases => '-H', :desc => "The root name of the host.  Defaults to s3.amazonaws.com."
     method_option :limit, :aliases => '-l', :type => :string, :desc => 'Rate limit for serving (ie. 50K, 1.0M)'
     def server
       store = nil


### PR DESCRIPTION
fake-s3 already binds "h" to --help:

$ fakes3 -h 127.0.0.1 -p 8080 -r /tmp/fakes3/
ERROR: "fakes3 help" was called with arguments ["127.0.0.1", "-p", "8080", "-r", "/tmp/fakes3/"]
Usage: "fakes3 help [COMMAND]"
