### PR TITLE
s/max_keys/max-keys/ when parsing url query parameters

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -65,7 +65,7 @@ module FakeS3
           query = {
             :marker => s_req.query["marker"] ? s_req.query["marker"].to_s : nil,
             :prefix => s_req.query["prefix"] ? s_req.query["prefix"].to_s : nil,
-            :max_keys => s_req.query["max_keys"] ? s_req.query["max_keys"].to_s : nil,
+            :max_keys => s_req.query["max-keys"] ? Integer(s_req.query["max-keys"].to_s) : nil,
             :delimiter => s_req.query["delimiter"] ? s_req.query["delimiter"].to_s : nil
           }
           bq = bucket_obj.query_for_range(query)


### PR DESCRIPTION
According to http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html , the parameter is max-keys, not max_keys.
You need the conversion to an int as well, since you're gonna use max_keys as an int in the rest of the code. But I'm no rubyist, so I don't know if that conversion is idiomatic.