### PR TITLE
Implementing If-None-Match and If-Modified-Since

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -90,6 +90,21 @@ module FakeS3
           return
         end
 
+        if_none_match = request["If-None-Match"]
+        if if_none_match == "\"#{real_obj.md5}\"" or if_none_match == "*"
+          response.status = 304
+          return
+        end
+
+        if_modified_since = request["If-Modified-Since"]
+        if if_modified_since
+          time = Time.httpdate(if_modified_since)
+          if time >= Time.iso8601(real_obj.modified_date)
+            response.status = 304
+            return
+          end 
+        end
+
         response.status = 200
         response['Content-Type'] = real_obj.content_type
         stat = File::Stat.new(real_obj.io.path)


### PR DESCRIPTION
Updating the GET implementation so that the If-None-Match and If-Modified-Since headers are handled.  This is especially useful for clients that want to cache resources, provided they save the ETag or Last-Modified headers in preceding GET requests.

Note: Sorry about the back and forth Curtis.  I misunderstood what you were looking for in the last submission.  This has only the changes associated with this update and none of the merges.  

Thanks!
