### PR TITLE
Fix incorrect variable when setting `custom_metadata`

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -219,12 +219,13 @@ module FakeS3
       metadata[:content_type] = request.header["content-type"].first
       metadata[:size] = File.size(content)
       metadata[:modified_date] = File.mtime(content).utc.iso8601()
+      metadata[:custom_metadata] = {}
 
       # Add custom metadata from the request header
       request.header.each do |key, value|
         match = /^x-amz-meta-(.*)$/.match(key)
-        if match
-          metadata_struct[:custom_metadata][match[1]] = value.join(', ')
+        if match && (match_key = match[1])
+          metadata[:custom_metadata][match_key] = value.join(', ')
         end
       end
       return metadata


### PR DESCRIPTION
The variable `metadata_struct` isn’t defined in `#create_metadata`, which (obviously) would explode, though it wasn’t immediately clear from the thrown exception and stacktrace, as it was something along the lines of:

```
ERROR NoMethodError: undefined method `md5' for nil:NilClass
```

Which is due to FileStore returning `nil` from `#store_object` because `metadata_struct` is `nil` which leads to yet another NoMethodError being thrown, etc, etc. This should fix that though.
