### PR TITLE
FakeS3::FileStore#copy_object should not remove the src object

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,15 @@ GEM
       builder
       mime-types
       xml-simple
+    aws-sdk-v1 (1.59.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
     builder (3.2.2)
+    json (1.8.1)
     mime-types (1.25)
+    mini_portile (0.6.1)
+    nokogiri (1.6.4.1)
+      mini_portile (~> 0.6.0)
     rake (10.1.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -28,6 +35,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-s3
+  aws-sdk-v1
   bundler (>= 1.0.0)
   fakes3!
   rake

--- a/fakes3.gemspec
+++ b/fakes3.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "right_aws"
   s.add_development_dependency "rest-client"
   s.add_development_dependency "rake"
-  #s.add_development_dependency "aws-sdk"
+  s.add_development_dependency "aws-sdk-v1"
   #s.add_development_dependency "ruby-debug"
   #s.add_development_dependency "debugger"
   s.add_dependency "thor"

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -152,7 +152,6 @@ module FakeS3
 
       src_obj = src_bucket.find(src_name)
       dst_bucket.add(obj)
-      src_bucket.remove(src_obj)
       return obj
     end
 

--- a/test/aws_sdk_commands_test.rb
+++ b/test/aws_sdk_commands_test.rb
@@ -1,0 +1,23 @@
+require 'test/test_helper'
+require 'aws-sdk-v1'
+
+class AwsSdkCommandsTest < Test::Unit::TestCase
+  def setup
+    @s3 = AWS::S3.new(:access_key_id => '123',
+                      :secret_access_key => 'abc',
+                      :s3_endpoint => 'localhost',
+                      :s3_port => 10453,
+                      :use_ssl => false)
+  end
+
+  def test_copy_to
+    bucket = @s3.buckets["test_copy_to"]
+    object = bucket.objects["key1"]
+    object.write("asdf")
+
+    assert object.exists?
+    object.copy_to("key2")
+
+    assert_equal 2, bucket.objects.count
+  end
+end


### PR DESCRIPTION
When using the `copy_object` method, the src object is removed.

Here is a script to show the issue using the aws-sdk gem:

``` ruby
s3 = AWS::S3.new(
  :access_key_id => '123',
  :secret_access_key => 'abc',
  :s3_endpoint => 'localhost',
  :s3_port => 8888,
  :use_ssl => false
)

b = s3.buckets["test"]
b.objects["a"].write("foo!")

o = b.objects["a"]
o.copy_to("b")

puts b.objects.size # 1 which is wrong, should be 2
```
