### PR TITLE
Don't fail in store_object on missing Content-Type

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -168,7 +168,12 @@ module FakeS3
 
         # TODO put a tmpfile here first and mv it over at the end
 
-        match=request.content_type.match(/^multipart\/form-data; boundary=(.+)/)
+        match = nil
+
+        unless request.content_type.nil?
+          match=request.content_type.match(/^multipart\/form-data; boundary=(.+)/)
+        end
+
       	boundary = match[1] if match
         if boundary
           boundary = WEBrick::HTTPUtils::dequote(boundary)


### PR DESCRIPTION
This fixes #66 for me. I was running into issues with simple PUTs from boto that didn't specify a Content-Type. I've had trouble writing a failing test though. Not sure if it comes down to an older version of boto or something else I'm missing.