### PR TITLE
List objects response never has isTruncated set to true

### DIFF
--- a/lib/fakes3/sorted_object_list.rb
+++ b/lib/fakes3/sorted_object_list.rb
@@ -80,7 +80,7 @@ module FakeS3
           if count <= max_keys
             ms.matches << s3_object
           else
-            is_truncated = true
+            ms.is_truncated = true
             break
           end
         end


### PR DESCRIPTION
Property is_truncated is not set on returned S3MatchSet object. This causes listings to always indicate that response is not truncated.