### PR TITLE
Vagrant development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,2 @@
 source 'https://rubygems.org'
-gem 'fakes3', :path => '.' # for dev and test, use local fakes3
-# Specify your gem's dependencies in fakes3.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,12 +21,15 @@ GEM
     mini_portile (0.6.1)
     nokogiri (1.6.4.1)
       mini_portile (~> 0.6.0)
+    power_assert (0.2.2)
     rake (10.1.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     right_aws (3.1.0)
       right_http_connection (>= 1.2.5)
     right_http_connection (1.4.0)
+    test-unit (3.0.9)
+      power_assert
     thor (0.18.1)
     xml-simple (1.1.2)
 
@@ -41,3 +44,4 @@ DEPENDENCIES
   rake
   rest-client
   right_aws
+  test-unit

--- a/README.md
+++ b/README.md
@@ -44,16 +44,24 @@ Then ensure that the following packages are installed (boto, s3cmd)
     > pip install boto
     > brew install s3cmd
 
-
-Start the test server using
-
-    rake test_server
-
-Then in another terminal window run
+Run the tests with
 
     rake test
 
-It is a still a TODO to get this to be just one command
+### In a VM
+
+Install virtualbox and vagrant, and run
+
+    vagrant up
+
+This will bootstrap a development environment in an ubuntu VM. To ssh into the
+machine:
+
+    vagrant ssh
+
+To run the tests from inside the VM:
+
+    bundle exec rake test
 
 ## More Information
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "."
   t.test_files =
     FileList['test/*_test.rb'].exclude('test/s3_commands_test.rb')
-  test_server = spawn('bundle exec bin/fakes3 --port 10453 --root test_root')
+  test_server = spawn('bundle exec bin/fakes3 --port 10453 --root test_root', :err => '/dev/null')
   Signal.trap('EXIT') { Process.kill('SIGINT', test_server) }
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -8,11 +8,8 @@ Rake::TestTask.new(:test) do |t|
   t.libs << "."
   t.test_files =
     FileList['test/*_test.rb'].exclude('test/s3_commands_test.rb')
-end
-
-desc "Run the test_server"
-task :test_server do |t|
-  system("bundle exec bin/fakes3 --port 10453 --root test_root")
+  test_server = spawn('bundle exec bin/fakes3 --port 10453 --root test_root')
+  Signal.trap('EXIT') { Process.kill('SIGINT', test_server) }
 end
 
 task :default => :test

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,7 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision "shell", path: "bootstrap.sh", privileged: false, keep_color: true
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,14 @@
+set -e
+
+# cd straight to /vagrant on login
+if ! grep -q 'cd \/vagrant' /home/vagrant/.bashrc; then
+  echo 'cd /vagrant' >> /home/vagrant/.bashrc
+fi
+cd /vagrant
+
+# Install dependencies
+sudo apt-add-repository -y ppa:brightbox/ruby-ng
+sudo apt-get update --quiet
+sudo apt-get install -y ruby2.2 ruby2.2-dev git python-boto s3cmd
+sudo gem install bundler
+bundle install

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,9 @@ if ! grep -q 'cd \/vagrant' /home/vagrant/.bashrc; then
 fi
 cd /vagrant
 
+# Fix hosts file
+echo '127.0.0.1 posttest.localhost' | sudo tee /etc/hosts
+
 # Install dependencies
 sudo apt-add-repository -y ppa:brightbox/ruby-ng
 sudo apt-get update --quiet

--- a/fakes3.gemspec
+++ b/fakes3.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rest-client"
   s.add_development_dependency "rake"
   s.add_development_dependency "aws-sdk-v1"
+  s.add_development_dependency "test-unit"
   #s.add_development_dependency "ruby-debug"
   #s.add_development_dependency "debugger"
   s.add_dependency "thor"


### PR DESCRIPTION
Setting up a development environment to hack on fakes3 is a bit of a pain at the moment, as it involves installing a bunch of dependencies and messing with the /etc/hosts file. This pull request adds a `Vagrantfile` that makes it easy to spin up a development environment in a VM.
- Added Vagrantfile and bootstrap script
- Fixed gemspec
- Updated the `rake test` command to spin up a test server on its own
