### PR TITLE
AWS SDK V2 tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,13 +12,26 @@ GEM
       builder
       mime-types
       xml-simple
+    aws-sdk (2.0.26)
+      aws-sdk-resources (= 2.0.26)
+    aws-sdk-core (2.0.26)
+      builder (~> 3.0)
+      jmespath (~> 1.0)
+      multi_json (~> 1.0)
+      multi_xml (~> 0.5)
+    aws-sdk-resources (2.0.26)
+      aws-sdk-core (= 2.0.26)
     aws-sdk-v1 (1.59.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     builder (3.2.2)
+    jmespath (1.0.2)
+      multi_json (~> 1.0)
     json (1.8.1)
     mime-types (1.25)
     mini_portile (0.6.1)
+    multi_json (1.10.1)
+    multi_xml (0.5.5)
     nokogiri (1.6.4.1)
       mini_portile (~> 0.6.0)
     rake (10.1.0)
@@ -35,6 +48,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-s3
+  aws-sdk (~> 2)
   aws-sdk-v1
   bundler (>= 1.0.0)
   fakes3!

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ Bundler::GemHelper.install_tasks
 Rake::TestTask.new(:test) do |t|
   t.libs << "."
   t.test_files =
-    FileList['test/*_test.rb'].exclude('test/s3_commands_test.rb')
+    FileList['test/*_test.rb'].exclude('test/s3_commands_test.rb', 'test/aws_sdk_v2_commands_test.rb')
 end
 
 desc "Run the test_server"

--- a/fakes3.gemspec
+++ b/fakes3.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "right_aws"
   s.add_development_dependency "rest-client"
   s.add_development_dependency "rake"
+  s.add_development_dependency "aws-sdk", "~> 2"
   s.add_development_dependency "aws-sdk-v1"
+
   #s.add_development_dependency "ruby-debug"
   #s.add_development_dependency "debugger"
   s.add_dependency "thor"

--- a/test/aws_sdk_v2_commands_test.rb
+++ b/test/aws_sdk_v2_commands_test.rb
@@ -1,0 +1,64 @@
+require 'test/test_helper'
+require 'aws-sdk'
+
+class AwsSdkV2CommandsTest < Test::Unit::TestCase
+  def setup
+
+    @creds = Aws::Credentials.new('123', 'abc')
+    @s3    = Aws::S3::Client.new(credentials: @creds, region: 'us-east-1', endpoint: 'http://localhost:10453/')
+    @resource = Aws::S3::Resource.new(client: @s3)
+    @bucket = @resource.create_bucket(bucket: 'v2_bucket')
+  end
+
+  def test_create_bucket
+    bucket = @resource.create_bucket(bucket: 'v2_create_bucket')
+    assert_not_nil bucket
+
+    bucket_names = @resource.buckets.map(&:name)
+    assert(bucket_names.index("v2_create_bucket") >= 0)
+  end
+
+  def test_destroy_bucket
+    bucket = @resource.create_bucket(bucket: 'v2_delete_bucket')
+    bucket.delete
+
+    begin
+      @s3.head_bucket(bucket: 'v2_delete_bucket')
+      assert_fail("Shouldn't succeed here")
+    rescue
+    end
+  end
+
+  def test_create_object
+    object = @bucket.object('key')
+    object.put(body: 'test', content_length: 4)
+
+    assert_equal 'test', object.get.body.string
+  end
+
+  def test_delete_object
+    object = @bucket.object('exists')
+    object.put(body: 'test', content_length: 4)
+
+    assert_equal 'test', object.get.body.string
+
+    object.delete
+
+    assert_raise Aws::S3::Errors::NoSuchKey do
+      object.get
+    end
+  end
+
+  def test_copy_object
+    bucket = @resource.create_bucket(bucket: 'testing_copy')
+
+    object = bucket.object("key_one")
+    object.put(body: 'asdf', content_length: 4)
+
+    # TODO: explore why 'key1' won't work but 'key_one' will
+    object2 = bucket.object('key_two')
+    object2.copy_from(copy_source: 'testing_copy/key_one')
+
+    assert_equal 2, bucket.objects.count
+  end
+end

--- a/test/aws_sdk_v2_commands_test.rb
+++ b/test/aws_sdk_v2_commands_test.rb
@@ -32,14 +32,14 @@ class AwsSdkV2CommandsTest < Test::Unit::TestCase
 
   def test_create_object
     object = @bucket.object('key')
-    object.put(body: 'test', content_length: 4)
+    object.put(body: 'test')
 
     assert_equal 'test', object.get.body.string
   end
 
   def test_delete_object
     object = @bucket.object('exists')
-    object.put(body: 'test', content_length: 4)
+    object.put(body: 'test')
 
     assert_equal 'test', object.get.body.string
 
@@ -52,7 +52,7 @@ class AwsSdkV2CommandsTest < Test::Unit::TestCase
 
   def test_copy_object  
     object = @bucket.object("key_one")
-    object.put(body: 'asdf', content_length: 4)
+    object.put(body: 'asdf')
 
     # TODO: explore why 'key1' won't work but 'key_one' will
     object2 = @bucket.object('key_two')

--- a/test/aws_sdk_v2_commands_test.rb
+++ b/test/aws_sdk_v2_commands_test.rb
@@ -3,7 +3,6 @@ require 'aws-sdk'
 
 class AwsSdkV2CommandsTest < Test::Unit::TestCase
   def setup
-
     @creds = Aws::Credentials.new('123', 'abc')
     @s3    = Aws::S3::Client.new(credentials: @creds, region: 'us-east-1', endpoint: 'http://localhost:10453/')
     @resource = Aws::S3::Resource.new(client: @s3)


### PR DESCRIPTION
This PR adds basic tests for version 2 of the AWS SDK.

Unfortunately I couldn't get the tests to pass with the entire suite.  It seems to be related to this issue, where the content length is not accurate, causing the request to hang: https://github.com/aws/aws-sdk-ruby/issues/241

I'm still investigating the issue, but for now I have excluded the tests from running when `rake test` is run. If you change the line in the Rakefile to `t.test_files = ['test/aws_sdk_v2_commands_test.rb']`, you'll see that the tests pass when run independently. This isn't ideal but I figured I'd make the PR anyway since others using V2 may find it useful.