### PR TITLE
Added :DoNotReverseLookup => true to WEBrick config

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -514,7 +514,8 @@ module FakeS3
       @ssl_key_path = ssl_key_path
       webrick_config = {
         :BindAddress => @address,
-        :Port => @port
+        :Port => @port,
+        :DoNotReverseLookup => true
       }
       if !@ssl_cert_path.to_s.empty?
         webrick_config.merge!(


### PR DESCRIPTION
There is a bug in WEBrick that in some circumstances (maybe only Linux) causes serious latency due to performing reverse DNS lookup on each connection.

A fix was added yesterday: https://github.com/ruby/ruby/pull/731.

This is a fix for the current and previous versions of Ruby.
