### PR TITLE
add quiet (-q) option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,17 +16,15 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     builder (3.2.2)
-    byebug (4.0.1)
-      columnize (= 0.9.0)
-      rb-readline (= 0.5.2)
-    columnize (0.9.0)
     json (1.8.1)
+    metaclass (0.0.4)
     mime-types (1.25)
     mini_portile (0.6.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     nokogiri (1.6.4.1)
       mini_portile (~> 0.6.0)
     rake (10.1.0)
-    rb-readline (0.5.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     right_aws (3.1.0)
@@ -42,8 +40,8 @@ DEPENDENCIES
   aws-s3
   aws-sdk-v1
   bundler (>= 1.0.0)
-  byebug
   fakes3!
+  mocha
   rake
   rest-client
   right_aws

--- a/fakes3.gemspec
+++ b/fakes3.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rest-client"
   s.add_development_dependency "rake"
   s.add_development_dependency "aws-sdk-v1"
+  s.add_development_dependency "mocha"
   #s.add_development_dependency "ruby-debug"
   #s.add_development_dependency "debugger"
   s.add_dependency "thor"

--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -11,6 +11,7 @@ module FakeS3
     method_option :port, :type => :numeric, :aliases => '-p', :required => true
     method_option :address, :type => :string, :aliases => '-a', :required => false, :desc => "Bind to this address. Defaults to 0.0.0.0"
     method_option :hostname, :type => :string, :aliases => '-H', :desc => "The root name of the host.  Defaults to s3.amazonaws.com."
+    method_option :quiet, :type => :boolean, :aliases => '-q', :desc => "Quiet; do not write anything to standard output."
     method_option :limit, :aliases => '-l', :type => :string, :desc => 'Rate limit for serving (ie. 50K, 1.0M)'
     method_option :sslcert, :type => :string, :desc => 'Path to SSL certificate'
     method_option :sslkey, :type => :string, :desc => 'Path to SSL certificate key'
@@ -52,8 +53,8 @@ module FakeS3
         abort "If you specify an SSL certificate you must also specify an SSL certificate key"
       end
 
-      puts "Loading FakeS3 with #{root} on port #{options[:port]} with hostname #{hostname}"
-      server = FakeS3::Server.new(address,options[:port],store,hostname,ssl_cert_path,ssl_key_path)
+      puts "Loading FakeS3 with #{root} on port #{options[:port]} with hostname #{hostname}" unless options[:quiet]
+      server = FakeS3::Server.new(address,options[:port],store,hostname,ssl_cert_path,ssl_key_path,options[:quiet])
       server.serve
     end
 

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -505,7 +505,7 @@ module FakeS3
 
 
   class Server
-    def initialize(address,port,store,hostname,ssl_cert_path,ssl_key_path)
+    def initialize(address, port, store, hostname, ssl_cert_path, ssl_key_path, quiet)
       @address = address
       @port = port
       @store = store
@@ -525,6 +525,14 @@ module FakeS3
           }
         )
       end
+
+      if quiet
+        webrick_config.merge!(
+          :Logger => WEBrick::Log.new("/dev/null"),
+          :AccessLog => []
+        )
+      end
+
       @server = WEBrick::HTTPServer.new(webrick_config)
     end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,0 +1,16 @@
+require 'test/test_helper'
+require 'fakes3/cli'
+
+class CLITest < Test::Unit::TestCase
+  def setup
+    super
+    FakeS3::Server.any_instance.stubs(:serve)
+  end
+
+  def test_quiet_mode
+    script = FakeS3::CLI.new([], :root => '.', :port => 4567, :quiet => true)
+    assert_output('') do
+      script.invoke(:server)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 require 'test/unit'
+require 'mocha/test_unit'
 require 'rubygems'
 require 'bundler/setup'
 require 'fakes3'


### PR DESCRIPTION
I'm using fake-s3 to run a bunch of tests in a rails app. The server lives in an outside process that is started/stopped by a test helper. Everything works nicely but I get the logs from the fake-s3 webrick server:
```
# Running tests with run options --seed 24883:
...................................................................................Loading FakeS3 with /tmp/d20150323-2330-1oeac27 on port 12345 with hostname s3.amazonaws.com
[2015-03-23 08:56:55] INFO  WEBrick 1.3.1
[2015-03-23 08:56:55] INFO  ruby 2.2.0 (2014-12-25) [x86_64-linux]
[2015-03-23 08:56:55] INFO  WEBrick::HTTPServer#start: pid=2341 port=12345
localhost - - [23/Mar/2015:08:56:56 UTC] "PUT /foobar.xml HTTP/1.1" 200 0
- -> /foobar.xml
localhost - - [23/Mar/2015:08:56:56 UTC] "PUT /foobar.xml HTTP/1.1" 200 0
- -> /foobar.xml
```

I'd like to keep my tests output clean, so I added a quiet option to the fake-s3 server. Enabling it will remove all the logs from the fake-s3 server and the underlying webrick server.

Eg:
```shell
fakes3 -r /mnt/fakes3_root -p 4567 -q
```


About the PR, I added a test file for the `FakeS3::CLI` class. I needed to stub the `serve` call on line 58. I used [mocha](http://gofreerange.com/mocha/docs/) for that. I hope it's alright.
Last thing: in the `Gemfile.lock`, they were some references to `bye-bug`. This gem is neither listed in the `fakes3.gemspec` nor in the `Gemfile`, so my `$ bundle install` execution removed it. 