### PR TITLE
Solved multipart upload from java (still working with s3cmd)

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -477,6 +477,11 @@ module FakeS3
       return s_req
     end
 
+    def gral_strip(string, chars)
+      chars = Regexp.escape(chars)
+      string.gsub(/\A[#{chars}]+|[#{chars}]+\z/, "")
+    end
+
     def parse_complete_multipart_upload request
       parts_xml   = ""
       request.body { |chunk| parts_xml << chunk }
@@ -487,7 +492,7 @@ module FakeS3
       parts_xml.collect do |xml|
         {
           number: xml[/\<PartNumber\>(\d+)\<\/PartNumber\>/, 1].to_i,
-          etag:   xml[/\<ETag\>\"(.+)\"\<\/ETag\>/, 1]
+          etag:   gral_strip(xml[/\<ETag\>(.+)\<\/ETag\>/, 1], "\"")
         }
       end
     end

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -477,8 +477,9 @@ module FakeS3
       return s_req
     end
 
-    def gral_strip(string, chars)
-      chars = Regexp.escape(chars)
+    # Strips any of a set of characters from the start and end of a string.
+    def strip(string, strip_chars)
+      chars = Regexp.escape(strip_chars)
       string.gsub(/\A[#{chars}]+|[#{chars}]+\z/, "")
     end
 
@@ -492,7 +493,7 @@ module FakeS3
       parts_xml.collect do |xml|
         {
           number: xml[/\<PartNumber\>(\d+)\<\/PartNumber\>/, 1].to_i,
-          etag:   gral_strip(xml[/\<ETag\>(.+)\<\/ETag\>/, 1], "\"")
+          etag:   strip(xml[/\<ETag\>(.+)\<\/ETag\>/, 1], "\"") # Strip quotation marks if present
         }
       end
     end

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -488,12 +488,12 @@ module FakeS3
       request.body { |chunk| parts_xml << chunk }
 
       # TODO: I suck at parsing xml
-      parts_xml = parts_xml.scan /\<Part\>.*?<\/Part\>/m
+      parts_xml = parts_xml.scan /<Part>.*?<\/Part>/m
 
       parts_xml.collect do |xml|
         {
-          number: xml[/\<PartNumber\>(\d+)\<\/PartNumber\>/, 1].to_i,
-          etag:   strip(xml[/\<ETag\>(.+)\<\/ETag\>/, 1], "\"") # Strip quotation marks if present
+          number: xml[/<PartNumber>(\d+)<\/PartNumber>/, 1].to_i,
+          etag:   strip(xml[/<ETag>(.+)<\/ETag>/, 1], "\"") # Strip quotation marks if present
         }
       end
     end


### PR DESCRIPTION
Previously, when parsing the complete multipart upload, quotation marks were expected in the ETags. The Java client don't use quotation marks at all, so they are sometimes present but not always. To solve that:
- get away the quotations in the etag regex
- introduced a function to strip/trim caracters
- used that function to strip the "optional" quotation marks
  Note: Im new to ruby so maybe there is a better way to strip. I used http://stackoverflow.com/questions/3165891/ruby-string-strip-defined-characters
