### PR TITLE
use ruby-1.8 compatible hash

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -486,8 +486,8 @@ module FakeS3
 
       parts_xml.collect do |xml|
         {
-          number: xml[/\<PartNumber\>(\d+)\<\/PartNumber\>/, 1].to_i,
-          etag:   xml[/\<ETag\>\"(.+)\"\<\/ETag\>/, 1]
+          :number => xml[/\<PartNumber\>(\d+)\<\/PartNumber\>/, 1].to_i,
+          :etag   => xml[/\<ETag\>\"(.+)\"\<\/ETag\>/, 1]
         }
       end
     end


### PR DESCRIPTION
We used fakes3-0.1.7 on some VMs with ruby-1.8, after an update to fakes3-0.2.1 this did not work because of a ruby-1.9-style hash. As it's only one hash i changed it to ruby-1.8 syntax to keep compatibility.