### PR TITLE
Add support for Delete Multiple Objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ test_root
 
 # Don't check in RVM/rbenv files
 .ruby-version
+
+fakes3.sublime-workspace

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ Bundler::GemHelper.install_tasks
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "."
-  t.test_files =
+  t.test_files = 
     FileList['test/*_test.rb'].exclude('test/s3_commands_test.rb')
 end
 

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -22,8 +22,9 @@ module FakeS3
     GET_ACL = "GET_ACL"
     SET_ACL = "SET_ACL"
     MOVE = "MOVE"
-    DELETE_OBJECT = "DELETE_OBJECT"
     DELETE_BUCKET = "DELETE_BUCKET"
+    DELETE_OBJECT = "DELETE_OBJECT"
+    DELETE_OBJECTS = "DELETE_OBJECTS"
 
     attr_accessor :bucket,:object,:type,:src_bucket,
                   :src_object,:method,:webrick_request,
@@ -73,12 +74,7 @@ module FakeS3
         if bucket_obj
           response.status = 200
           response['Content-Type'] = "application/xml"
-          query = {
-            :marker => s_req.query["marker"] ? s_req.query["marker"].to_s : nil,
-            :prefix => s_req.query["prefix"] ? s_req.query["prefix"].to_s : nil,
-            :max_keys => s_req.query["max_keys"] ? s_req.query["max_keys"].to_s : nil,
-            :delimiter => s_req.query["delimiter"] ? s_req.query["delimiter"].to_s : nil
-          }
+          query = get_options(s_req)
           bq = bucket_obj.query_for_range(query)
           response.body = XmlAdapter.bucket_query(bq)
         else
@@ -229,6 +225,10 @@ module FakeS3
     end
 
     def do_POST(request,response)
+      if request.query_string =~ /delete/i
+        return do_DELETE(request, response)
+      end
+
       s_req = normalize_request(request)
       key   = request.query['key']
       query = CGI::parse(request.request_uri.query || "")
@@ -308,6 +308,9 @@ module FakeS3
         @store.delete_object(bucket_obj,s_req.object,s_req.webrick_request)
       when Request::DELETE_BUCKET
         @store.delete_bucket(s_req.bucket)
+      when Request::DELETE_OBJECTS
+        bucket_obj = @store.get_bucket(s_req.bucket)
+        @store.delete_objects(bucket_obj,s_req.webrick_request)
       end
 
       response.status = 204
@@ -441,6 +444,10 @@ module FakeS3
       else
         s_req.object = path[1..-1]
       end
+
+      if webrick_req.query_string =~ /delete/i
+        s_req.type = Request::DELETE_OBJECTS
+      end
     end
 
     # This method takes a webrick request and generates a normalized FakeS3 request
@@ -500,6 +507,15 @@ module FakeS3
         puts "#{k}:#{v}"
       end
       puts "----------End Dump -------------"
+    end
+
+    def get_options(s_req)
+      return {
+            :marker => s_req.query["marker"] ? s_req.query["marker"].to_s : nil,
+            :prefix => s_req.query["prefix"] ? s_req.query["prefix"].to_s : nil,
+            :max_keys => s_req.query["max_keys"] ? s_req.query["max_keys"].to_s : nil,
+            :delimiter => s_req.query["delimiter"] ? s_req.query["delimiter"].to_s : nil
+          }
     end
   end
 

--- a/test/aws_sdk_commands_test.rb
+++ b/test/aws_sdk_commands_test.rb
@@ -28,4 +28,35 @@ class AwsSdkCommandsTest < Test::Unit::TestCase
     assert object.exists?
     assert_equal "thisisaverybigfile", object.read
   end
+
+  def test_delete_multiple
+    #assemble
+    bucket = @s3.buckets["test_delete_multiple"]
+    object = bucket.objects["key1"]
+    object.write("asdf")
+    object.copy_to("key2")
+    assert_equal 2, bucket.objects.count
+
+    #act
+    bucket.objects.delete_all
+
+    #assert
+    assert_equal 0, bucket.objects.count
+  end
+
+  def test_delete_multiple_with_prefix
+    #assemble
+    bucket = @s3.buckets["test_delete_multiple"]
+    object = bucket.objects["key1"]
+    object.write("asdf")
+    object.copy_to("prefix1/key2")
+    object.copy_to("prefix1/key3")
+    assert_equal 3, bucket.objects.count
+
+    #act
+    bucket.objects.with_prefix('prefix1/').delete_all
+
+    #assert
+    assert_equal 1, bucket.objects.count
+  end
 end


### PR DESCRIPTION
Added support multi-object deletion per the S3 api as described at http://docs.aws.amazon.com/AmazonS3/latest/API/multiobjectdeleteapi.html