### PR TITLE
Store non-custom metadata (ie. KMS settings) from PutObject requests

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -263,14 +263,18 @@ module FakeS3
       metadata[:content_type] = request.header["content-type"].first
       metadata[:size] = File.size(content)
       metadata[:modified_date] = File.mtime(content).utc.iso8601(SUBSECOND_PRECISION)
+      metadata[:amazon_metadata] = {}
       metadata[:custom_metadata] = {}
 
       # Add custom metadata from the request header
       request.header.each do |key, value|
-        match = /^x-amz-meta-(.*)$/.match(key)
-        if match && (match_key = match[1])
+        match = /^x-amz-([^-]+)-(.*)$/.match(key)
+        next unless match
+        if match[1].eql?('meta') && (match_key = match[2])
           metadata[:custom_metadata][match_key] = value.join(', ')
+          next
         end
+        metadata[:amazon_metadata][key.gsub(/^x-amz-/, '')] = value.join(', ')
       end
       return metadata
     end

--- a/test/aws_sdk_commands_test.rb
+++ b/test/aws_sdk_commands_test.rb
@@ -28,4 +28,32 @@ class AwsSdkCommandsTest < Test::Unit::TestCase
     assert object.exists?
     assert_equal "thisisaverybigfile", object.read
   end
+
+  def test_metadata
+    file_path = './test_root/test_metadata/metaobject'
+    FileUtils.rm_rf file_path
+
+    bucket = @s3.buckets["test_metadata"]
+    object = bucket.objects["metaobject"]
+    object.write(
+      'data',
+      # this is sent as header x-amz-storage-class
+      :storage_class => 'REDUCED_REDUNDANCY',
+      # this is sent as header x-amz-meta-custom1
+      :metadata => {
+        "custom1" => "foobar"
+      }
+    )
+    assert object.exists?
+    metadata_file = YAML.load(IO.read("#{file_path}/.fakes3_metadataFFF/metadata"))
+
+    assert metadata_file.has_key?(:custom_metadata), 'Metadata file does not contain a :custom_metadata key'
+    assert metadata_file[:custom_metadata].has_key?('custom1'), ':custom_metadata does not contain field "custom1"'
+    assert_equal 'foobar', metadata_file[:custom_metadata]['custom1'], '"custom1" does not equal expected value "foobar"'
+
+    assert metadata_file.has_key?(:amazon_metadata), 'Metadata file does not contain an :amazon_metadata key'
+    assert metadata_file[:amazon_metadata].has_key?('storage-class'), ':amazon_metadata does not contain field "storage-class"'
+    assert_equal 'REDUCED_REDUNDANCY', metadata_file[:amazon_metadata]['storage-class'], '"storage-class" does not equal expected value "REDUCED_REDUNDANCY"'
+
+  end
 end


### PR DESCRIPTION
I'm using fake-s3 for some cucumber tests, and I need a way to verify that the application under test is setting certain parameters (ie. sse-kms encryption settings) in the PutObject request. These appear as 'x-amz' headers, but as they aren't custom metadata, they aren't stored by fake-s3 so I can't check them.

This PR stores non-custom metadata under a separate 'amazon_metadata' entry so it gets written to the metadata file for that object.

Happy to discuss other approaches if you don't like the way I've done this.