### PR TITLE
Added support and test for If-Match on object get

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -99,6 +99,12 @@ module FakeS3
           return
         end
 
+        if_match = request["If-Match"]
+        if if_match and (if_match != "\"#{real_obj.md5}\"" and if_match != "*")
+          response.status = 412
+          return
+        end
+
         if_none_match = request["If-None-Match"]
         if if_none_match == "\"#{real_obj.md5}\"" or if_none_match == "*"
           response.status = 304

--- a/test/right_aws_commands_test.rb
+++ b/test/right_aws_commands_test.rb
@@ -150,6 +150,22 @@ class RightAWSCommandsTest < Test::Unit::TestCase
 
   end
 
+  def test_if_match
+    @s3.put("s3media","if_match_test","Hello World 1!")
+    obj = @s3.get("s3media","if_match_test")
+    tag = obj[:headers]["etag"]
+    obj = @s3.get("s3media", "if_match_test", {"If-Match"=>tag})
+    assert_equal "Hello World 1!",obj[:object]
+    @s3.put("s3media","if_match_test","Hello World 2!")
+    begin
+      @s3.get("s3media", "if_match_test", {"If-Match"=>tag})
+    rescue RightAws::AwsError
+      # expected error for 412
+    else
+      fail 'Should have encountered an error due to the server not returning a response due to caching'
+    end
+  end
+
   def test_if_none_match
     @s3.put("s3media","if_none_match_test","Hello World 1!")
     obj = @s3.get("s3media","if_none_match_test")


### PR DESCRIPTION
I discovered a unit test failed in a project of mine when I tested against fake-s3.   It looks like "If-Match" was not implemented.  I added support based on the spec at http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGET.html and mimiced the code I saw for If-Not-Match, and added a corresponding unit test.

Let me know if there's anything else I should include to get support for this feature added.

Thanks,
Phil