### PR TITLE
Test for IP v4/v6 before assuming sub-domain bucket name

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -9,6 +9,7 @@ require 'fakes3/xml_adapter'
 require 'fakes3/bucket_query'
 require 'fakes3/unsupported_operation'
 require 'fakes3/errors'
+require 'ipaddr'
 
 module FakeS3
   class Request
@@ -452,7 +453,7 @@ module FakeS3
       s_req.path = webrick_req.path
       s_req.is_path_style = true
 
-      if !@root_hostnames.include?(host)
+      if !@root_hostnames.include?(host) && !(IPAddr.new(host) rescue nil)
         s_req.bucket = host.split(".")[0]
         s_req.is_path_style = false
       end


### PR DESCRIPTION
Test for IP address before assuming a sub-domain host. Fixes issue https://github.com/jubos/fake-s3/issues/114 and https://github.com/jubos/fake-s3/commit/bb35f3902a33b9c6d017faa255fa2986ba5e8bff#diff-aab88656cc39d9ecac1bb11128b9c777R218.