### PR TITLE
Fix wrong throw in mutipart method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fakes3 (0.2.1)
+    fakes3 (0.2.2)
       builder
       thor
 
@@ -16,23 +16,21 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     builder (3.2.2)
-    byebug (4.0.1)
-      columnize (= 0.9.0)
-      rb-readline (= 0.5.2)
-    columnize (0.9.0)
     json (1.8.1)
     mime-types (1.25)
     mini_portile (0.6.1)
     nokogiri (1.6.4.1)
       mini_portile (~> 0.6.0)
+    power_assert (0.2.4)
     rake (10.1.0)
-    rb-readline (0.5.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     right_aws (3.1.0)
       right_http_connection (>= 1.2.5)
     right_http_connection (1.4.0)
-    thor (0.18.1)
+    test-unit (3.1.2)
+      power_assert
+    thor (0.19.1)
     xml-simple (1.1.2)
 
 PLATFORMS
@@ -42,8 +40,11 @@ DEPENDENCIES
   aws-s3
   aws-sdk-v1
   bundler (>= 1.0.0)
-  byebug
   fakes3!
   rake
   rest-client
   right_aws
+  test-unit
+
+BUNDLED WITH
+   1.10.5

--- a/fakes3.gemspec
+++ b/fakes3.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rest-client"
   s.add_development_dependency "rake"
   s.add_development_dependency "aws-sdk-v1"
+  s.add_development_dependency "test-unit"
   #s.add_development_dependency "ruby-debug"
   #s.add_development_dependency "debugger"
   s.add_dependency "thor"

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -228,7 +228,10 @@ module FakeS3
         File.open(content_path, 'rb') { |f| chunk = f.read }
         etag = Digest::MD5.hexdigest(chunk)
 
-        raise new Error "invalid file chunk" unless part[:etag] == etag
+        if part[:etag] && part[:etag].to_s != etag.to_s
+          raise "invalid file chunk #{part[:number]}: etag: #{part[:etag]} expected: #{etag}, #{part[:etag] == etag}"
+        end
+
         complete_file << chunk
         part_paths    << part_path
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,3 @@
 require 'test/unit'
-require 'rubygems'
 require 'bundler/setup'
 require 'fakes3'


### PR DESCRIPTION
 - added test-unit to dev dpendencies for ruby 2.2.0+
 - require rubygems not needed