### PR TITLE
Handle nil in comparable methods for S3Object

### DIFF
--- a/fakes3.gemspec
+++ b/fakes3.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rest-client"
   s.add_development_dependency "rake"
   s.add_development_dependency "aws-sdk-v1"
+  s.add_development_dependency "test-unit"
   #s.add_development_dependency "ruby-debug"
   #s.add_development_dependency "debugger"
   s.add_dependency "thor"

--- a/lib/fakes3/s3_object.rb
+++ b/lib/fakes3/s3_object.rb
@@ -8,12 +8,12 @@ module FakeS3
     end
 
     def eql?(object)
-      @name == object.name
+      object.is_a?(self.class) ? (@name == object.name) : false
     end
 
     # Sort by the object's name
     def <=>(object)
-      @name <=> object.name
+      object.is_a?(self.class) ? (@name <=> object.name) : nil
     end
   end
 end


### PR DESCRIPTION
In ruby 2.3.0, exceptions in the `<=>` method of `Comparable` are no longer automatically rescued.  The changes here handle `nil` for `Comparable` methods.

Tests (which required the addition of `test-unit` to the `.gemspec`):
```
Finished in 10.381011 seconds.
-------------------------------------------------------------------------------------------------------------
27 tests, 39 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
--------------------------------------------------------------------------------------------------------------
2.60 tests/s, 3.76 assertions/s
```
Under ruby 2.3.0, tests have errors without this change.
