### PR TITLE
Add support for content-disposition and content-type/content-disposition request parameters

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -85,7 +85,10 @@ module FakeS3
         metadata = File.open(File.join(obj_root, "metadata")) { |file| YAML::load(file) }
         real_obj.name = object_name
         real_obj.md5 = metadata[:md5]
-        real_obj.content_type = metadata.fetch(:content_type) { "application/octet-stream" }
+        real_obj.content_type = request.query['response-content-type'] ||
+          metadata.fetch(:content_type) { "application/octet-stream" }
+        real_obj.content_disposition = request.query['response-content-disposition'] ||
+          metadata[:content_disposition]
         real_obj.content_encoding = metadata.fetch(:content_encoding) # if metadata.fetch(:content_encoding)
         real_obj.io = RateLimitableFile.open(File.join(obj_root, "content"), 'rb')
         real_obj.size = metadata.fetch(:size) { 0 }
@@ -151,6 +154,7 @@ module FakeS3
       obj.name = dst_name
       obj.md5 = src_metadata[:md5]
       obj.content_type = src_metadata[:content_type]
+      obj.content_disposition = src_metadata[:content_disposition]
       obj.content_encoding = src_metadata[:content_encoding] # if src_metadata[:content_encoding]
       obj.size = src_metadata[:size]
       obj.modified_date = src_metadata[:modified_date]
@@ -206,6 +210,7 @@ module FakeS3
         obj.name = object_name
         obj.md5 = metadata_struct[:md5]
         obj.content_type = metadata_struct[:content_type]
+        obj.content_disposition = metadata_struct[:content_disposition]
         obj.content_encoding = metadata_struct[:content_encoding] # if metadata_struct[:content_encoding]
         obj.size = metadata_struct[:size]
         obj.modified_date = metadata_struct[:modified_date]
@@ -269,6 +274,9 @@ module FakeS3
       metadata = {}
       metadata[:md5] = Digest::MD5.file(content).hexdigest
       metadata[:content_type] = request.header["content-type"].first
+      if request.header['content-disposition']
+        metadata[:content_disposition] = request.header['content-disposition'].first
+      end
       content_encoding = request.header["content-encoding"].first
       metadata[:content_encoding] = content_encoding
       #if content_encoding

--- a/lib/fakes3/s3_object.rb
+++ b/lib/fakes3/s3_object.rb
@@ -1,7 +1,7 @@
 module FakeS3
   class S3Object
     include Comparable
-    attr_accessor :name,:size,:creation_date,:modified_date,:md5,:io,:content_type,:content_encoding,:custom_metadata
+    attr_accessor :name,:size,:creation_date,:modified_date,:md5,:io,:content_type,:content_disposition,:content_encoding,:custom_metadata
 
     def hash
       @name.hash

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -124,6 +124,7 @@ module FakeS3
           response.header['Content-Encoding'] = real_obj.content_encoding
         end
 
+        response['Content-Disposition'] = real_obj.content_disposition if real_obj.content_disposition
         stat = File::Stat.new(real_obj.io.path)
 
         response['Last-Modified'] = Time.iso8601(real_obj.modified_date).httpdate
@@ -334,7 +335,7 @@ module FakeS3
 
       response['Access-Control-Allow-Origin']   = '*'
       response['Access-Control-Allow-Methods']  = 'PUT, POST, HEAD, GET, OPTIONS'
-      response['Access-Control-Allow-Headers']  = 'Accept, Content-Type, Authorization, Content-Length, ETag, X-CSRF-Token'
+      response['Access-Control-Allow-Headers']  = 'Accept, Content-Type, Authorization, Content-Length, ETag, X-CSRF-Token, Content-Disposition'
       response['Access-Control-Expose-Headers'] = 'ETag'
     end
 

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -15,7 +15,7 @@ class PostTest < Test::Unit::TestCase
       assert_equal(response.code, 200)
       assert_equal(response.headers[:access_control_allow_origin],"*")
       assert_equal(response.headers[:access_control_allow_methods], "PUT, POST, HEAD, GET, OPTIONS")
-      assert_equal(response.headers[:access_control_allow_headers], "Accept, Content-Type, Authorization, Content-Length, ETag, X-CSRF-Token")
+      assert_equal(response.headers[:access_control_allow_headers], "Accept, Content-Type, Authorization, Content-Length, ETag, X-CSRF-Token, Content-Disposition")
       assert_equal(response.headers[:access_control_expose_headers], "ETag")
     end
   end


### PR DESCRIPTION
This PR adds support for two things:
- S3 objects can have content dispositions
- Support for the `response-content-type` and `response-content-disposition` when getting an object to override an object's stored content type/content disposition
