### PR TITLE
DELETE bucket without params fixed

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -341,8 +341,9 @@ module FakeS3
         end
 
         if elems.size == 0
-          raise UnsupportedOperation
-        elsif elems.size == 1
+          raise UnsupportedOperation unless s_req.bucket
+          s_req.type = Request::DELETE_BUCKET          
+        elsif (elems.size == 1) && s_req.is_path_style
           s_req.type = Request::DELETE_BUCKET
           s_req.query = query
         else


### PR DESCRIPTION
Hi,

When a bucket is deleted with method DELETE and no params fake-s3 throws unsupported operation error. Its fixed so when bucket name is part of the url  and http method is DELETE we should delete the bucket.

Can you please review and accept this pull request? If you think there are more cases that needs to be handled let me know.

Regards,
Vikram