### PR TITLE
Fix list objects with max-keys param

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -77,7 +77,7 @@ module FakeS3
           query = {
             :marker => s_req.query["marker"] ? s_req.query["marker"].to_s : nil,
             :prefix => s_req.query["prefix"] ? s_req.query["prefix"].to_s : nil,
-            :max_keys => s_req.query["max_keys"] ? s_req.query["max_keys"].to_s : nil,
+            :max_keys => s_req.query["max-keys"] ? s_req.query["max-keys"].to_i : nil,
             :delimiter => s_req.query["delimiter"] ? s_req.query["delimiter"].to_s : nil
           }
           bq = bucket_obj.query_for_range(query)


### PR DESCRIPTION
As per http://docs.aws.amazon.com/AmazonS3/latest/API/v2-RESTBucketGET.html
The param is named 'max-keys' not 'max_keys'

lib/fakes3/sorted_object_list.rb:61 expects options[:max_keys] to be int
