### PR TITLE
Close file stream after YAML serialization.

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -80,7 +80,7 @@ module FakeS3
       begin
         real_obj = S3Object.new
         obj_root = File.join(@root,bucket,object_name,SHUCK_METADATA_DIR)
-        metadata = YAML.load(File.open(File.join(obj_root,"metadata"),'rb'))
+        metadata = File.open(File.join(obj_root,"metadata")) { |file| YAML::load(file)}
         real_obj.name = object_name
         real_obj.md5 = metadata[:md5]
         real_obj.content_type = metadata.fetch(:content_type) { "application/octet-stream" }

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -80,7 +80,7 @@ module FakeS3
       begin
         real_obj = S3Object.new
         obj_root = File.join(@root,bucket,object_name,SHUCK_METADATA_DIR)
-        metadata = File.open(File.join(obj_root,"metadata")) { |file| YAML::load(file)}
+        metadata = File.open(File.join(obj_root,"metadata")) { |file| YAML::load(file) }
         real_obj.name = object_name
         real_obj.md5 = metadata[:md5]
         real_obj.content_type = metadata.fetch(:content_type) { "application/octet-stream" }


### PR DESCRIPTION
After getting a file, metadata file stream is still open. This commit fixes that.