### PR TITLE
Close file stream for HEAD request

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -160,7 +160,7 @@ module FakeS3
         response['Content-Length'] = File::Stat.new(real_obj.io.path).size
         if s_req.http_verb == 'HEAD'
           response.body = ""
-		  real_obj.io.close
+	   real_obj.io.close
         else
           response.body = real_obj.io
         end

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -160,6 +160,7 @@ module FakeS3
         response['Content-Length'] = File::Stat.new(real_obj.io.path).size
         if s_req.http_verb == 'HEAD'
           response.body = ""
+		  real_obj.io.close
         else
           response.body = real_obj.io
         end


### PR DESCRIPTION
When we have HEAD request, we don't need file stream so we should close it. This commit solves problem if we want to delete data after HEAD request. Maybe we should split GET and HEAD request processing because this causes exception when we want to check if file exists (and it doesn't).