### PR TITLE
Change redirect code from 307 to 303

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -282,9 +282,14 @@ module FakeS3
         response['Etag'] = "\"#{real_obj.md5}\""
 
         if success_action_redirect
+          object_params = [ [ :bucket, s_req.bucket ], [ :key, key ] ]
+          location_uri = URI.parse(success_action_redirect)
+          original_location_params = URI.decode_www_form(String(location_uri.query))
+          location_uri.query = URI.encode_www_form(original_location_params + object_params)
+
           response.status      = 303
           response.body        = ""
-          response['Location'] = success_action_redirect
+          response['Location'] = location_uri.to_s
         else
           response.status = success_action_status || 204
           if response.status == "201"

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -282,7 +282,7 @@ module FakeS3
         response['Etag'] = "\"#{real_obj.md5}\""
 
         if success_action_redirect
-          response.status      = 307
+          response.status      = 303
           response.body        = ""
           response['Location'] = success_action_redirect
         else

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -27,7 +27,7 @@ class PostTest < Test::Unit::TestCase
       'success_action_redirect'=>'http://somewhere.else.com/',
       'file'=>File.new(__FILE__,"rb")
     ) { |response|
-      assert_equal(response.code, 307)
+      assert_equal(response.code, 303)
       assert_equal(response.headers[:location], 'http://somewhere.else.com/')
     }
   end

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -24,11 +24,11 @@ class PostTest < Test::Unit::TestCase
     res = RestClient.post(
       @url,
       'key'=>'uploads/12345/${filename}',
-      'success_action_redirect'=>'http://somewhere.else.com/',
+      'success_action_redirect'=>'http://somewhere.else.com/?foo=bar',
       'file'=>File.new(__FILE__,"rb")
     ) { |response|
       assert_equal(response.code, 303)
-      assert_equal(response.headers[:location], 'http://somewhere.else.com/')
+      assert_equal(response.headers[:location], 'http://somewhere.else.com/?foo=bar&bucket=posttest&key=uploads%2F12345%2Fpost_test.rb')
     }
   end
 


### PR DESCRIPTION
This matches the behavior of the real S3. Example: [S3 Upload Examples](http://docs.aws.amazon.com/AmazonS3/latest/dev/HTTPPOSTExamples.html) under "Sample Response".

The difference between 303 and 307 is significant. The HTTP 1.1 standard says that a 307 indicates the request should be repeated using the same method and post data, whereas a 303 always indicates a `GET` request. As a result, a `POST` to Fake S3 with `success_action_redirect` set will subsequently `POST` to `success_action_redirect` instead of `GET` as expected.

This also adds the `bucket` and `key` HTTP parameters to the redirect location, also matching the behavior of real S3. This is necessary for the success page to reference the newly uploaded objects. 

~~This affects tools such as [Shrine](https://github.com/janko-m/shrine).~~ Update: More than just Shrine, this affects the common idiom of browser-based uploads ([example](http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-post-example.html)), including pre-signed posts ([example](https://github.com/janko-m/shrine/blob/master/doc/direct_s3.md#strategy-b-static)).