### PR TITLE
Have filestore respect quiet mode.

### DIFF
--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -21,7 +21,7 @@ module FakeS3
       if options[:root]
         root = File.expand_path(options[:root])
         # TODO Do some sanity checking here
-        store = FileStore.new(root)
+        store = FileStore.new(root, !!options[:quiet])
       end
 
       if store.nil?

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -16,10 +16,11 @@ module FakeS3
     # sub second precision.
     SUBSECOND_PRECISION = 3
 
-    def initialize(root)
+    def initialize(root, quiet_mode)
       @root = root
       @buckets = []
       @bucket_hash = {}
+      @quiet_mode = quiet_mode
       Dir[File.join(root,"*")].each do |bucket|
         bucket_name = File.basename(bucket)
         bucket_obj = Bucket.new(bucket_name,Time.now,[])
@@ -95,8 +96,10 @@ module FakeS3
         real_obj.custom_metadata = metadata.fetch(:custom_metadata) { {} }
         return real_obj
       rescue
-        puts $!
-        $!.backtrace.each { |line| puts line }
+        unless @quiet_mode
+          puts $!
+          $!.backtrace.each { |line| puts line }
+        end
         return nil
       end
     end
@@ -210,8 +213,10 @@ module FakeS3
         bucket.add(obj)
         return obj
       rescue
-        puts $!
-        $!.backtrace.each { |line| puts line }
+        unless @quiet_mode
+          puts $!
+          $!.backtrace.each { |line| puts line }
+        end
         return nil
       end
     end


### PR DESCRIPTION
When running a test suite for a rails application, the 404's in the test suite end up having the test log have several thousand lines of errors when it's intended.  This change simply has file_store.rb respect the quiet mode flag and not output anything to the console.