### PR TITLE
Fix list-objects returning nothing after restarting

### DIFF
--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -21,7 +21,7 @@ module FakeS3
       @bucket_hash = {}
       Dir[File.join(root,"*")].each do |bucket|
         bucket_name = File.basename(bucket)
-        bucket_obj = Bucket.new(bucket_name,Time.now,[])
+        bucket_obj = Bucket.new(bucket_name,Time.now,get_objects(bucket_name, bucket))
         @buckets << bucket_obj
         @bucket_hash[bucket_name] = bucket_obj
       end
@@ -278,5 +278,11 @@ module FakeS3
       end
       return metadata
     end
+     private
+     def get_objects bucket_name, path
+       Dir[File.join(path, '*')].map do |filepath|
+         get_object(bucket_name, File.basename(filepath), nil)
+       end
+     end 
   end
 end


### PR DESCRIPTION
Currently if fake-s3 is restarted, it always returns an empty response for the `list-objects` action. However, the objects are still there and can be fetched with `get-object` if you already know the key.

This PR is similar to [this one](https://github.com/jubos/fake-s3/pull/69), but including the extra fixes in comments from @Allactaga and @mark2997.