### PR TITLE
Urldecode X-Amz-Copy-Source

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -4,6 +4,7 @@ require 'webrick/https'
 require 'openssl'
 require 'securerandom'
 require 'cgi'
+require 'uri'
 require 'fakes3/util'
 require 'fakes3/file_store'
 require 'fakes3/xml_adapter'
@@ -448,7 +449,8 @@ module FakeS3
       # for multipart copy
       copy_source = webrick_req.header["x-amz-copy-source"]
       if copy_source and copy_source.size == 1
-        src_elems   = copy_source.first.split("/")
+        copy_source = URI.unescape copy_source.first
+        src_elems   = copy_source.split("/")
         root_offset = src_elems[0] == "" ? 1 : 0
         s_req.src_bucket = src_elems[root_offset]
         s_req.src_object = src_elems[1 + root_offset,src_elems.size].join("/")

--- a/test/right_aws_commands_test.rb
+++ b/test/right_aws_commands_test.rb
@@ -115,6 +115,13 @@ class RightAWSCommandsTest < Test::Unit::TestCase
     assert_equal "Hello World", obj[:object]
   end
 
+  def test_intra_bucket_copy_urlencoded_source
+    @s3.put("s3media", "original==.txt", "Hello World")
+    @s3.copy("s3media", "original==.txt", "s3media", "copy.txt")
+    obj = @s3.get("s3media", "copy.txt")
+    assert_equal "Hello World", obj[:object]
+  end
+
   def test_copy_in_place
     @s3.put("s3media", "copy-in-place", "Hello World")
     @s3.copy("s3media", "copy-in-place", "s3media","copy-in-place")


### PR DESCRIPTION
S3 documentation says that X-Amz-Copy-Source header must be urlencoded: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html