### PR TITLE
Add ability to control CORS Headers (resolves #130)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 
 desc "Run the test_server"
 task :test_server do |t|
-  system("bundle exec bin/fakes3 --port 10453 --root test_root")
+  system("bundle exec bin/fakes3 --port 10453 --root test_root  --corspostputallowheaders 'Authorization, Content-Length, Cache-Control'")
 end
 
 task :default => :test

--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -15,6 +15,11 @@ module FakeS3
     method_option :limit, :aliases => '-l', :type => :string, :desc => 'Rate limit for serving (ie. 50K, 1.0M)'
     method_option :sslcert, :type => :string, :desc => 'Path to SSL certificate'
     method_option :sslkey, :type => :string, :desc => 'Path to SSL certificate key'
+    method_option :corsorigin, :type => :string, :desc => 'Access-Control-Allow-Origin header return value'
+    method_option :corsmethods, :type => :string, :desc => 'Access-Control-Allow-Methods header return value'
+    method_option :corspreflightallowheaders, :type => :string, :desc => 'Access-Control-Allow-Headers header return value for preflight OPTIONS requests'
+    method_option :corspostputallowheaders, :type => :string, :desc => 'Access-Control-Allow-Headers header return value for POST and PUT requests'
+    method_option :corsexposeheaders, :type => :string, :desc => 'Access-Control-Expose-Headers header return value'
 
     def server
       store = nil
@@ -45,6 +50,13 @@ module FakeS3
         end
       end
 
+      cors_options = {}
+      cors_options['allow_origin'] = options[:corsorigin] if options[:corsorigin]
+      cors_options['allow_methods'] = options[:corsmethods] if options[:corsmethods]
+      cors_options['preflight_allow_headers'] = options[:corspreflightallowheaders] if options[:corspreflightallowheaders]
+      cors_options['post_put_allow_headers'] = options[:corspostputallowheaders] if options[:corspostputallowheaders]
+      cors_options['expose_headers'] = options[:corsexposeheaders] if options[:corsexposeheaders]
+
       address = options[:address]
       ssl_cert_path = options[:sslcert]
       ssl_key_path = options[:sslkey]
@@ -54,7 +66,7 @@ module FakeS3
       end
 
       puts "Loading FakeS3 with #{root} on port #{options[:port]} with hostname #{hostname}" unless options[:quiet]
-      server = FakeS3::Server.new(address,options[:port],store,hostname,ssl_cert_path,ssl_key_path, quiet: !!options[:quiet])
+      server = FakeS3::Server.new(address,options[:port],store,hostname,ssl_cert_path,ssl_key_path, quiet: !!options[:quiet], cors_options: cors_options)
       server.serve
     end
 

--- a/test/post_test.rb
+++ b/test/post_test.rb
@@ -29,6 +29,8 @@ class PostTest < Test::Unit::TestCase
     ) { |response|
       assert_equal(response.code, 303)
       assert_equal(response.headers[:location], 'http://somewhere.else.com/?foo=bar&bucket=posttest&key=uploads%2F12345%2Fpost_test.rb')
+      # Tests that CORS Headers can be set from command line
+      assert_equal(response.headers[:access_control_allow_headers], 'Authorization, Content-Length, Cache-Control')
     }
   end
 
@@ -40,6 +42,8 @@ class PostTest < Test::Unit::TestCase
       'file'=>File.new(__FILE__,"rb")
     ) { |response|
       assert_equal(response.code, 200)
+      # Tests that CORS Headers can be set from command line
+      assert_equal(response.headers[:access_control_allow_headers], 'Authorization, Content-Length, Cache-Control')
     }
   end
 
@@ -52,6 +56,8 @@ class PostTest < Test::Unit::TestCase
     ) { |response|
       assert_equal(response.code, 201)
       assert_match(%r{^\<\?xml.*uploads/12345/post_test\.rb}m, response.body)
+      # Tests that CORS Headers can be set from command line
+      assert_equal(response.headers[:access_control_allow_headers], 'Authorization, Content-Length, Cache-Control')
     }
   end
 


### PR DESCRIPTION
The issue only required modifying the Allowed-Headers,
but it seemed strange to add the ability to control
that one without being able to control the others

- Current behavior without added flags is unnaffected
- No existing assertions are changed
- Added assertions to demonstrate control of CORS Headers