### PR TITLE
Support buckets with dots in them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ There are some prerequisites to actually being able to run the unit/integration 
 On macOS, edit your /etc/hosts and add the following line:
 
     127.0.0.1 posttest.localhost
+    127.0.0.1 v2.bucket.localhost
 
 Then ensure that the following packages are installed (boto, s3cmd):
 

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -378,12 +378,12 @@ module FakeS3
         end
 
         if elems.size == 0
-          if !s_req.is_path_style
-            s_req.type = Request::DELETE_BUCKET
-          else
+          if s_req.is_path_style
             s_req.type = Request::DELETE_OBJECTS
             s_req.query = query
             s_req.webrick_request = webrick_req
+          else
+            s_req.type = Request::DELETE_BUCKET
           end
         elsif elems.size == 1
           s_req.type = webrick_req.query_string == 'delete' ? Request::DELETE_OBJECTS : Request::DELETE_BUCKET

--- a/test/aws_sdk_v2_commands_test.rb
+++ b/test/aws_sdk_v2_commands_test.rb
@@ -6,24 +6,25 @@ class AwsSdkV2CommandsTest < Test::Unit::TestCase
     @creds = Aws::Credentials.new('123', 'abc')
     @s3    = Aws::S3::Client.new(credentials: @creds, region: 'us-east-1', endpoint: 'http://localhost:10453/')
     @resource = Aws::S3::Resource.new(client: @s3)
-    @bucket = @resource.create_bucket(bucket: 'v2.bucket')
+    @bucket = @resource.create_bucket(bucket: 'v2_bucket')
 
     # Delete all objects to avoid sharing state between tests
     @bucket.objects.each(&:delete)
   end
 
   def test_create_bucket
-    assert_not_nil @bucket
+    bucket = @resource.create_bucket(bucket: 'v2_create_bucket')
+    assert_not_nil bucket
 
     bucket_names = @resource.buckets.map(&:name)
-    assert_not_nil bucket_names.index("v2.bucket")
+    assert_not_nil bucket_names.index("v2_create_bucket")
   end
 
   def test_destroy_bucket
     @bucket.delete
 
     begin
-      @s3.head_bucket(bucket: 'v2.bucket')
+      @s3.head_bucket(bucket: 'v2_bucket')
       assert_fail("Shouldn't succeed here")
     rescue
     end
@@ -31,6 +32,14 @@ class AwsSdkV2CommandsTest < Test::Unit::TestCase
 
   def test_create_object
     object = @bucket.object('key')
+    object.put(body: 'test')
+
+    assert_equal 'test', object.get.body.string
+  end
+
+  def test_bucket_with_dots
+    bucket = @resource.create_bucket(bucket: 'v2.bucket')
+    object = bucket.object('key')
     object.put(body: 'test')
 
     assert_equal 'test', object.get.body.string

--- a/test/aws_sdk_v2_commands_test.rb
+++ b/test/aws_sdk_v2_commands_test.rb
@@ -6,25 +6,24 @@ class AwsSdkV2CommandsTest < Test::Unit::TestCase
     @creds = Aws::Credentials.new('123', 'abc')
     @s3    = Aws::S3::Client.new(credentials: @creds, region: 'us-east-1', endpoint: 'http://localhost:10453/')
     @resource = Aws::S3::Resource.new(client: @s3)
-    @bucket = @resource.create_bucket(bucket: 'v2_bucket')
+    @bucket = @resource.create_bucket(bucket: 'v2.bucket')
 
     # Delete all objects to avoid sharing state between tests
     @bucket.objects.each(&:delete)
   end
 
   def test_create_bucket
-    bucket = @resource.create_bucket(bucket: 'v2_create_bucket')
-    assert_not_nil bucket
+    assert_not_nil @bucket
 
     bucket_names = @resource.buckets.map(&:name)
-    assert(bucket_names.index("v2_create_bucket") >= 0)
+    assert_not_nil bucket_names.index("v2.bucket")
   end
 
   def test_destroy_bucket
     @bucket.delete
 
     begin
-      @s3.head_bucket(bucket: 'v2_bucket')
+      @s3.head_bucket(bucket: 'v2.bucket')
       assert_fail("Shouldn't succeed here")
     rescue
     end


### PR DESCRIPTION
In the v2 API, DELETE_BUCKET may be performed by passing the bucket name
as a subdomain. It appears the presence of dots may invoke this
behavior, so handling of the delete bucket operation needed updating
here too.

Because the v2 tests now pass the bucket by subdomain, extra subdomains
will probably need to be resolved locally via /etc/hosts for the tests
to pass. To reduce the number of such domains required, the delete
bucket test was updated to use the same bucket as the rest of the tests.

This supersedes #88 and #152.