### PR TITLE
Add a command line option for passing version 1.3 needed license key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fakes3 (1.2.1)
+    fakes3 (1.3.0)
       builder
       thor
       xml-simple
@@ -74,4 +74,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.15.4
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Many commands are supported, including put, get, list, copy, and make bucket.
 
 ## Running
 
-To run the server, you just specify a root and a port.
+To run the server, you must specify a root, a port, and your license key.
 
-    fakes3 -r /mnt/fakes3_root -p 4567
+    fakes3 -r /mnt/fakes3_root -p 4567 --license YOUR_LICENSE_KEY
 
 ## Licensing
 
@@ -28,6 +28,8 @@ As of the latest version, we are licensing with Super Source. To get a license, 
 https://supso.org/projects/fake-s3 
 
 Depending on your company's size, the license may be free. It is also free for individuals.
+
+You pass the license key to Fake S3 with the command line option --license YOUR_LICENSE_KEY.
 
 ## Connecting to Fake S3
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 
 desc "Run the test_server"
 task :test_server do |t|
-  system("bundle exec bin/fakes3 --port 10453 --root test_root  --corspostputallowheaders 'Authorization, Content-Length, Cache-Control'")
+  system("bundle exec bin/fakes3 --port 10453 --license test --root test_root  --corspostputallowheaders 'Authorization, Content-Length, Cache-Control'")
 end
 
 task :default => :test

--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -20,8 +20,28 @@ module FakeS3
     method_option :corspreflightallowheaders, :type => :string, :desc => 'Access-Control-Allow-Headers header return value for preflight OPTIONS requests'
     method_option :corspostputallowheaders, :type => :string, :desc => 'Access-Control-Allow-Headers header return value for POST and PUT requests'
     method_option :corsexposeheaders, :type => :string, :desc => 'Access-Control-Expose-Headers header return value'
+    method_option :license, :type => :string, :desc => 'Your license key, available at https://supso.org/projects/fake-s3'
 
     def server
+      license_key = options[:license]
+      if license_key.nil?
+        license_message = """
+======================
+As of version 1.3, Fake S3 requires a license key passed with --license YOUR_LICENSE_KEY.
+Please fix this before September 18, 2018.
+You can get a license at:
+https://supso.org/projects/fake-s3
+======================
+
+"""
+        licensing_required = Time.now > Time.utc(2018, 9, 19)
+        if licensing_required
+          abort license_message
+        else
+          warn license_message
+        end 
+      end
+      
       store = nil
       if options[:root]
         root = File.expand_path(options[:root])
@@ -65,7 +85,7 @@ module FakeS3
         abort "If you specify an SSL certificate you must also specify an SSL certificate key"
       end
 
-      puts "Loading FakeS3 with #{root} on port #{options[:port]} with hostname #{hostname}" unless options[:quiet]
+      puts "Loading Fake S3 with #{root} on port #{options[:port]} with hostname #{hostname}" unless options[:quiet]
       server = FakeS3::Server.new(address,options[:port],store,hostname,ssl_cert_path,ssl_key_path, quiet: !!options[:quiet], cors_options: cors_options)
       server.serve
     end

--- a/lib/fakes3/version.rb
+++ b/lib/fakes3/version.rb
@@ -1,3 +1,3 @@
 module FakeS3
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -10,7 +10,7 @@ class CLITest < Test::Unit::TestCase
   end
 
   def test_quiet_mode
-    script = FakeS3::CLI.new([], :root => '.', :port => 4567, :quiet => true)
+    script = FakeS3::CLI.new([], :root => '.', :port => 4567, :license => 'test', :quiet => true)
     assert_output('') do
       script.invoke(:server)
     end


### PR DESCRIPTION
Add a command line option for providing a license key with version 1.3 and up. Lack of a license key will leave a warning, then an error. For those using the latest version, please make sure to fix by Sep 18, 2018, because starting on Sep 19, the command line interface will require a license key.