### PR TITLE
Run as a Background Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ To run the server, you must specify a root, a port, and your license key.
 
     fakes3 -r /mnt/fakes3_root -p 4567 --license YOUR_LICENSE_KEY
 
+### Running in the background
+
+To run the server as a background process, use the -b flag. You can optionally specify where to write any output with the --output option.
+
+    fakes3 -r /mnt/fakes3_root -p 4567 -b --license YOUR_LICENSE_KEY
+
 ## Licensing
 
 As of the latest version, we are licensing with Super Source. To get a license, visit:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To run the server, you must specify a root, a port, and your license key.
 
 To run the server as a background process, use the -b flag. You can optionally specify where to write any output with the --output option.
 
-    fakes3 -r /mnt/fakes3_root -p 4567 -b --license YOUR_LICENSE_KEY
+    fakes3 -r /mnt/fakes3_root -p 4567 --license YOUR_LICENSE_KEY -b
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ To run the server, you must specify a root, a port, and your license key.
 
 ### Running in the background
 
-To run the server as a background process, use the -b flag. You can optionally specify where to write any output with the --output option.
+To run the server as a daemon process (in the background), use the -d flag. You can optionally specify where to write any output with the --output option.
 
-    fakes3 -r /mnt/fakes3_root -p 4567 --license YOUR_LICENSE_KEY -b
+    fakes3 -r /mnt/fakes3_root -p 4567 --license YOUR_LICENSE_KEY -d
 
 ## Licensing
 
 As of the latest version, we are licensing with Super Source. To get a license, visit:
 
-https://supso.org/projects/fake-s3 
+https://supso.org/projects/fake-s3
 
 Depending on your company's size, the license may be free. It is also free for individuals.
 
@@ -39,8 +39,8 @@ You pass the license key to Fake S3 with the command line option --license YOUR_
 
 ## Connecting to Fake S3
 
-Take a look at the test cases to see client example usage.  For now, Fake S3 is
-mainly tested with s3cmd, aws-s3 gem, and right_aws.  There are plenty more
+Take a look at the test cases to see client example usage. For now, Fake S3 is
+mainly tested with s3cmd, aws-s3 gem, and right_aws. There are plenty more
 libraries out there, and please do mention if other clients work or not.
 
 Here is a running list of [supported clients](https://github.com/jubos/fake-s3/wiki/Supported-Clients "Supported Clients")

--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -10,7 +10,7 @@ module FakeS3
     method_option :root, :type => :string, :aliases => '-r', :required => true
     method_option :port, :type => :numeric, :aliases => '-p', :required => true
     method_option :address, :type => :string, :aliases => '-a', :required => false, :desc => "Bind to this address. Defaults to all IP addresses of the machine."
-    method_option :hostname, :type => :string, :aliases => '-H', :desc => "The root name of the host.  Defaults to s3.amazonaws.com."
+    method_option :hostname, :type => :string, :aliases => '-H', :desc => "The root name of the host. Defaults to s3.amazonaws.com."
     method_option :quiet, :type => :boolean, :aliases => '-q', :desc => "Quiet; do not write anything to standard output."
     method_option :limit, :aliases => '-l', :type => :string, :desc => 'Rate limit for serving (ie. 50K, 1.0M)'
     method_option :sslcert, :type => :string, :desc => 'Path to SSL certificate'

--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -12,8 +12,8 @@ module FakeS3
     method_option :address, :type => :string, :aliases => '-a', :required => false, :desc => "Bind to this address. Defaults to all IP addresses of the machine."
     method_option :hostname, :type => :string, :aliases => '-H', :desc => "The root name of the host. Defaults to s3.amazonaws.com."
     method_option :quiet, :type => :boolean, :aliases => '-q', :desc => "Quiet; do not write anything to standard output."
-    method_option :background, :type => :boolean, :aliases => '-b', :required => false, :desc => 'Run the server process in the background. Defaults to false.'
-    method_option :output, :type => :string, :required => false, :desc => 'Optional file to log server output to. Only used if running in the background with -b.'
+    method_option :background, :type => :boolean, :aliases => '-b', :desc => "Run the server process in the background. Defaults to false."
+    method_option :output, :type => :string, :desc => "Optional file to log server output to. Only used if running in the background with -b."
     method_option :limit, :aliases => '-l', :type => :string, :desc => 'Rate limit for serving (ie. 50K, 1.0M)'
     method_option :sslcert, :type => :string, :desc => 'Path to SSL certificate'
     method_option :sslkey, :type => :string, :desc => 'Path to SSL certificate key'

--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -12,6 +12,8 @@ module FakeS3
     method_option :address, :type => :string, :aliases => '-a', :required => false, :desc => "Bind to this address. Defaults to all IP addresses of the machine."
     method_option :hostname, :type => :string, :aliases => '-H', :desc => "The root name of the host. Defaults to s3.amazonaws.com."
     method_option :quiet, :type => :boolean, :aliases => '-q', :desc => "Quiet; do not write anything to standard output."
+    method_option :background, :type => :boolean, :aliases => '-b', :required => false, :desc => 'Run the server process in the background. Defaults to false.'
+    method_option :output, :type => :string, :required => false, :desc => 'Optional file to log server output to. Only used if running in the background with -b.'
     method_option :limit, :aliases => '-l', :type => :string, :desc => 'Rate limit for serving (ie. 50K, 1.0M)'
     method_option :sslcert, :type => :string, :desc => 'Path to SSL certificate'
     method_option :sslkey, :type => :string, :desc => 'Path to SSL certificate key'
@@ -80,13 +82,15 @@ https://supso.org/projects/fake-s3
       address = options[:address]
       ssl_cert_path = options[:sslcert]
       ssl_key_path = options[:sslkey]
+      background = options[:background] || false
+      output = options[:output] || nil
 
       if (ssl_cert_path.nil? && !ssl_key_path.nil?) || (!ssl_cert_path.nil? && ssl_key_path.nil?)
         abort "If you specify an SSL certificate you must also specify an SSL certificate key"
       end
 
       puts "Loading Fake S3 with #{root} on port #{options[:port]} with hostname #{hostname}" unless options[:quiet]
-      server = FakeS3::Server.new(address,options[:port],store,hostname,ssl_cert_path,ssl_key_path, quiet: !!options[:quiet], cors_options: cors_options)
+      server = FakeS3::Server.new(address, options[:port], store, hostname, ssl_cert_path, ssl_key_path, quiet: !!options[:quiet], cors_options: cors_options, background: background, output: output)
       server.serve
     end
 

--- a/lib/fakes3/cli.rb
+++ b/lib/fakes3/cli.rb
@@ -12,8 +12,8 @@ module FakeS3
     method_option :address, :type => :string, :aliases => '-a', :required => false, :desc => "Bind to this address. Defaults to all IP addresses of the machine."
     method_option :hostname, :type => :string, :aliases => '-H', :desc => "The root name of the host. Defaults to s3.amazonaws.com."
     method_option :quiet, :type => :boolean, :aliases => '-q', :desc => "Quiet; do not write anything to standard output."
-    method_option :background, :type => :boolean, :aliases => '-b', :desc => "Run the server process in the background. Defaults to false."
-    method_option :output, :type => :string, :desc => "Optional file to log server output to. Only used if running in the background with -b."
+    method_option :daemon, :type => :boolean, :aliases => '-d', :desc => "Run the server process as a daemon (in the background). Defaults to false."
+    method_option :output, :type => :string, :desc => "Optional file to log server output to. Only used if running as a daemon with -d."
     method_option :limit, :aliases => '-l', :type => :string, :desc => 'Rate limit for serving (ie. 50K, 1.0M)'
     method_option :sslcert, :type => :string, :desc => 'Path to SSL certificate'
     method_option :sslkey, :type => :string, :desc => 'Path to SSL certificate key'
@@ -43,7 +43,7 @@ https://supso.org/projects/fake-s3
           warn license_message
         end
       end
-      
+
       store = nil
       if options[:root]
         root = File.expand_path(options[:root])
@@ -82,7 +82,7 @@ https://supso.org/projects/fake-s3
       address = options[:address]
       ssl_cert_path = options[:sslcert]
       ssl_key_path = options[:sslkey]
-      background = options[:background] || false
+      daemon = options[:daemon] || false
       output = options[:output] || nil
 
       if (ssl_cert_path.nil? && !ssl_key_path.nil?) || (!ssl_cert_path.nil? && ssl_key_path.nil?)
@@ -90,7 +90,7 @@ https://supso.org/projects/fake-s3
       end
 
       puts "Loading Fake S3 with #{root} on port #{options[:port]} with hostname #{hostname}" unless options[:quiet]
-      server = FakeS3::Server.new(address, options[:port], store, hostname, ssl_cert_path, ssl_key_path, quiet: !!options[:quiet], cors_options: cors_options, background: background, output: output)
+      server = FakeS3::Server.new(address, options[:port], store, hostname, ssl_cert_path, ssl_key_path, quiet: !!options[:quiet], cors_options: cors_options, daemon: daemon, output: output)
       server.serve
     end
 

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -583,13 +583,13 @@ module FakeS3
           :Logger => WEBrick::Log.new("/dev/null"),
           :AccessLog => []
         )
-      elsif extra_options[:background] && extra_options[:output]
+      elsif extra_options[:daemon] && extra_options[:output]
         webrick_config.merge!(
           :Logger => WEBrick::Log.new(extra_options[:output])
         )
       end
 
-      WEBrick::Daemon.start if extra_options[:background]
+      WEBrick::Daemon.start if extra_options[:daemon]
       @server = WEBrick::HTTPServer.new(webrick_config)
     end
 

--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -1,6 +1,7 @@
 require 'time'
 require 'webrick'
 require 'webrick/https'
+require 'webrick/log'
 require 'openssl'
 require 'securerandom'
 require 'cgi'
@@ -582,8 +583,13 @@ module FakeS3
           :Logger => WEBrick::Log.new("/dev/null"),
           :AccessLog => []
         )
+      elsif extra_options[:background] && extra_options[:output]
+        webrick_config.merge!(
+          :Logger => WEBrick::Log.new(extra_options[:output])
+        )
       end
 
+      WEBrick::Daemon.start if extra_options[:background]
       @server = WEBrick::HTTPServer.new(webrick_config)
     end
 


### PR DESCRIPTION
Added new CLI option flags:
- `--background`, aliased to `-b`. Runs the server using a Daemon process in the background.
- `--output`, sets the output location for the logger. Only used if `--background` is true, and the `quiet` mode flag has not been set.

I needed this to be able to run the FakeS3 server and my test suite easily in our docker container.

- [x] Tests passing.
- [x] CLA executed.