### PR TITLE
Add missing dependencies for ruby3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,60 +3,74 @@ PATH
   specs:
     fakes3 (2.0.0)
       builder
+      rexml
+      sorted_set
       thor
+      webrick
       xml-simple
 
 GEM
   remote: https://rubygems.org/
   specs:
+    aws-eventstream (1.1.1)
     aws-s3 (0.6.3)
       builder
       mime-types
       xml-simple
-    aws-sdk (2.10.73)
-      aws-sdk-resources (= 2.10.73)
-    aws-sdk-core (2.10.73)
+    aws-sdk (2.11.632)
+      aws-sdk-resources (= 2.11.632)
+    aws-sdk-core (2.11.632)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.73)
-      aws-sdk-core (= 2.10.73)
+    aws-sdk-resources (2.11.632)
+      aws-sdk-core (= 2.11.632)
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
-    aws-sigv4 (1.0.2)
-    builder (3.2.3)
-    domain_name (0.5.20170404)
+    aws-sigv4 (1.2.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+    builder (3.2.4)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     json (1.8.6)
-    metaclass (0.0.4)
-    mime-types (3.1)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
-    mini_portile2 (2.4.0)
-    mocha (1.3.0)
-      metaclass (~> 0.0.1)
+    mime-types-data (3.2021.0225)
+    mini_portile2 (2.5.1)
+    mocha (1.12.0)
     netrc (0.11.0)
-    nokogiri (1.10.5)
-      mini_portile2 (~> 2.4.0)
-    power_assert (1.1.1)
-    rake (12.2.1)
-    rest-client (2.0.2)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    power_assert (2.0.0)
+    racc (1.5.2)
+    rake (13.0.3)
+    rbtree (0.4.4)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rexml (3.2.5)
     right_aws (3.1.0)
       right_http_connection (>= 1.2.5)
-    right_http_connection (1.5.0)
-    test-unit (3.2.6)
+    right_http_connection (1.5.1)
+    set (1.0.1)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
+    test-unit (3.4.1)
       power_assert
-    thor (0.20.0)
+    thor (1.1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
-    xml-simple (1.1.5)
+    unf_ext (0.0.7.7)
+    webrick (1.7.0)
+    xml-simple (1.1.8)
 
 PLATFORMS
   ruby

--- a/fakes3.gemspec
+++ b/fakes3.gemspec
@@ -24,8 +24,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   #s.add_development_dependency "ruby-debug"
   #s.add_development_dependency "debugger"
-  s.add_dependency "thor"
   s.add_dependency "builder"
+  s.add_dependency "rexml"
+  s.add_dependency "sorted_set"
+  s.add_dependency "thor"
+  s.add_dependency "webrick"
   s.add_dependency "xml-simple"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
A number of default gems became bundled gems in ruby 3, so they need including in the gemspec dependencies

https://nts.strzibny.name/ruby-stdlib-default-bundled-gems/
