### PR TITLE
Remove hardcoded "localhost" for @hostname

### DIFF
--- a/lib/fakes3/server.rb
+++ b/lib/fakes3/server.rb
@@ -316,7 +316,7 @@ module FakeS3
             response.body = <<-eos.strip
               <?xml version="1.0" encoding="UTF-8"?>
               <PostResponse>
-                <Location>http://#{s_req.bucket}.localhost:#{@port}/#{key}</Location>
+                <Location>http://#{s_req.bucket}.#{@hostname}:#{@port}/#{key}</Location>
                 <Bucket>#{s_req.bucket}</Bucket>
                 <Key>#{key}</Key>
                 <ETag>#{response['Etag']}</ETag>


### PR DESCRIPTION
A small change to allow the post response to reflect custom hostnames.

I reckon this falls under the trivial exemption policy for the CLA.